### PR TITLE
Issues create issue bug

### DIFF
--- a/lib/github_api/api.rb
+++ b/lib/github_api/api.rb
@@ -170,6 +170,11 @@ module Github
 
     def _token_required
     end
+    
+    # Removes keys with empty values
+    def _remove_empty_values(params)
+      params.delete_if { |k, v| v.empty? } if params.is_a?(Hash)
+    end
 
   end # API
 end # Github

--- a/lib/github_api/issues.rb
+++ b/lib/github_api/issues.rb
@@ -38,6 +38,8 @@ module Github
       'direction' => %w[ desc asc ],
       'since'     => %r{\d{4}-\d{2}-\d{5}:\d{2}:\d{3}}
     }
+    
+    VALID_ISSUE_INPUTS = %w[ title body assignee milestone labels ]
 
     # Creates new Issues API
     def initialize(options = {})
@@ -164,7 +166,8 @@ module Github
 
       _normalize_params_keys(params)
       _merge_mime_type(:issue, params)
-      _filter_params_keys(VALID_MILESTONE_INPUTS, params)
+      _filter_params_keys(VALID_ISSUE_INPUTS, params)
+      _remove_empty_values(params)
 
       raise ArgumentError, "Required params are: :title" unless _validate_inputs(%w[ title ], params)
 


### PR DESCRIPTION
the method create_issue filtered the params for a milestone. additionally when committing an issue with an empty string for assignee, github returned a validation error. therefore i added a function to remove empty hash values.
