### PR TITLE
Removed call to _filter_params_keys in create_tree

### DIFF
--- a/lib/github_api/git_data/trees.rb
+++ b/lib/github_api/git_data/trees.rb
@@ -78,7 +78,6 @@ module Github
         _validate_user_repo_params(user, repo) unless user? && repo?
         _normalize_params_keys(params)
 
-        _filter_params_keys(VALID_TREE_PARAM_NAMES, params['tree'])
         _validate_params_values(VALID_TREE_PARAM_VALUES, params['tree'])
 
         post("/repos/#{user}/#{repo}/git/trees", params)


### PR DESCRIPTION
I had a go at refactoring _filter_params_keys to filter arrays inside of hashes, but it was a bit hairy. Better to get this API function working at first and then work out a solution for filtering keys.
