### PR TITLE
Only log to STDOUT when ENV['DEBUG'] is set

### DIFF
--- a/lib/github_api/connection.rb
+++ b/lib/github_api/connection.rb
@@ -54,7 +54,7 @@ module Github
           builder.use Faraday::Request::JSON
           builder.use Faraday::Request::Multipart
           builder.use Faraday::Request::UrlEncoded
-          builder.use Faraday::Response::Logger
+          builder.use Faraday::Response::Logger if ENV['DEBUG']
 
           builder.use Github::Request::OAuth2, oauth_token if oauth_token?
           builder.use Github::Request::BasicAuth, authentication if basic_authed?


### PR DESCRIPTION
I've disabled STDOUT logging when ENV['DEBUG'] is not set. I'm using this library in CLI scripts and would like the option of turning off the stdout logging. Otherwise it's a bit too noisy.
