### PR TITLE
Spell "Entity" correctly

### DIFF
--- a/lib/github_api/response/raise_error.rb
+++ b/lib/github_api/response/raise_error.rb
@@ -18,7 +18,7 @@ module Github
         raise Github::ResourceNotFound.new(response_message(env), env[:response_headers])
 
       when 422
-        raise Github::UnprocessableEntitty.new(response_message(env), env[:response_headers])
+        raise Github::UnprocessableEntity.new(response_message(env), env[:response_headers])
       when 500
         raise Github::InternalServerError.new(response_message(env), env[:response_headers])
       when 503


### PR DESCRIPTION
Think this was just a typo, as the word is spelled correctly in `lib/github/errors.rb`
