### PR TITLE
each_page should include the current page

### DIFF
--- a/lib/github_api/result.rb
+++ b/lib/github_api/result.rb
@@ -56,6 +56,7 @@ module Github
     # Iterator like each for response pages. If there are no pages to
     # iterate over this method will return nothing.
     def each_page
+      yield self
       while page_iterator.has_next?
         yield next_page #page_iterator.next
       end


### PR DESCRIPTION
According to the documentation, you should be able to write:

``` ruby
results = api.something.something()
results.each_page do |result_page|
    result_page.each do |r|
        # handle r
        puts 'handled'
    end
end
```

However, currently `each_page` does not include the first (current) page.  This is easiest to see if you use the above code and the resulting set is only one page long.
