### PR TITLE
Added rake dependency to development deps so that travis-ci will run

### DIFF
--- a/github_api.gemspec
+++ b/github_api.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'guard', '~> 0.8.8'
   gem.add_development_dependency 'guard-rspec', '0.5.7'
   gem.add_development_dependency 'guard-cucumber', '0.7.4'
+  gem.add_development_dependency 'rake', '0.9.2'
 end


### PR DESCRIPTION
Hi Peter,

it's nice to have travis-ci.org embedded in the Readme but it would be nicer, if it's green :)

This fix should make the ci server happy so that the badge will show green. All tests seem to run, so why not show it? 

Cheers,
Hendrik
