### PR TITLE
add dependency of nokogiri

### DIFF
--- a/github_api.gemspec
+++ b/github_api.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'faraday', '~> 0.7.6'
   gem.add_dependency 'multi_json', '~> 1.0'
   gem.add_dependency 'oauth2', '~> 0.5.2'
+  gem.add_dependency 'nokogiri', '~> 1.5.2'
 
   gem.add_development_dependency 'rspec', '>= 0'
   gem.add_development_dependency 'cucumber', '>= 0'


### PR DESCRIPTION
My Ruby-Fu is not very good but shouldn't nokogiri be declared as dependency, since it's used in [lib/github_api/response/xmlize.rb](https://github.com/peter-murach/github/blob/891e185d1c6d3a1f4c9577b30a71a5b8c8455913/lib/github_api/response/xmlize.rb#L7) ?
