### PR TITLE
Added attribute team_id for creating a repo + updated documentation

### DIFF
--- a/lib/github_api/repos.rb
+++ b/lib/github_api/repos.rb
@@ -40,6 +40,7 @@ module Github
       has_issues
       has_wiki
       has_downloads
+      team_id
     ].freeze
 
     VALID_REPO_TYPES = %w[ all public private member ].freeze
@@ -80,6 +81,8 @@ module Github
     #  <tt>:has_issues</tt> - Optional boolean - <tt>true</tt> to enable issues for this repository, <tt>false</tt> to disable them
     #  <tt>:has_wiki</tt> - Optional boolean - <tt>true</tt> to enable the wiki for this repository, <tt>false</tt> to disable it. Default is <tt>true</tt>
     #  <tt>:has_downloads</tt> Optional boolean - <tt>true</tt> to enable downloads for this repository
+    #  <tt>:org</tt> Optional string - The organisation in which this repository will be created
+    #  <tt>:team_id</tt> Optional number - The id of the team that will be granted access to this repository. This is only valid when creating a repo in an organization
     #
     # = Examples
     #  @github = Github.new


### PR DESCRIPTION
I added the 'team_id' attribute when creating a repository, used in conjunction with the 'org' attribute.
I made an attempt to run the tests, but I keep having random failing tests.

I tested the feature manually and it works.
