### PR TITLE
Query params maintained between pagination

### DIFF
--- a/lib/github_api/page_iterator.rb
+++ b/lib/github_api/page_iterator.rb
@@ -56,9 +56,11 @@ module Github
 
         page_request next_page_uri.split(QUERY_STR_SEP)[0], params
       else
-        page_request next_page_uri.split(QUERY_STR_SEP)[0],
-                                'page' => next_page,
-                                'per_page'=> parse_per_page_number(next_page_uri)
+        params = parse_query(next_page_uri.split(QUERY_STR_SEP).last)
+        params['page'] = next_page
+        params['per_page'] = parse_per_page_number(next_page_uri)
+
+        page_request next_page_uri.split(QUERY_STR_SEP)[0], params
       end
       update_page_links response.links
       response


### PR DESCRIPTION
This pull requests keeps optional query parameters between paginated responses.

---

Currently query params are dropped from subsequent pages.

eg.

``` ruby
issues = github.issues.list_rep('dannymidnight', 
                                'bugs', 
                                :state => closed,
                                :assignee => 'dannymidnight'
                                :per_page => 100)
```

Calling `issues.has_next_page?` will make request with `page` and `per_page` **however** `state` and `assignee` are missing.
