### PR TITLE
Add dependency of addressable

### DIFF
--- a/github_api.gemspec
+++ b/github_api.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'multi_json', '~> 1.3'
   gem.add_dependency 'oauth2', '~> 0.7'
   gem.add_dependency 'nokogiri', '~> 1.5.2'
+  gem.add_dependency 'addressable', '~> 2.2.8'
 
   gem.add_development_dependency 'rspec', '>= 0'
   gem.add_development_dependency 'cucumber', '>= 0'


### PR DESCRIPTION
Isn't `addressable` missing as dependency, since it's required in [`lib/github/request.rb`](https://github.com/peter-murach/github/blob/505e74e9aeabd909dd62cde0fa5123334fe25142/lib/github_api/request.rb#L4)?
