### PR TITLE
Support parameters for listing repositories.

### DIFF
--- a/lib/github_api/repos.rb
+++ b/lib/github_api/repos.rb
@@ -313,15 +313,17 @@ module Github
     def list(*args)
       params = args.extract_options!
       normalize! params
-      filter! %w[ org user type ], params
+
+      valid_user_repos_params = %w(type sort direction)
+      valid_org_repos_params  = %w(type)
 
       response = if (user_name = params.delete("user"))
-        get_request("/users/#{user_name}/repos", params)
+        get_request("/users/#{user_name}/repos", params.delete_if { |k, v| !valid_user_repos_params.include? k })
       elsif (org_name = params.delete("org"))
-        get_request("/orgs/#{org_name}/repos", params)
+        get_request("/orgs/#{org_name}/repos", params.delete_if { |k, v| !valid_org_repos_params.include? k })
       else
         # For authenticated user
-        get_request("/user/repos", params)
+        get_request("/user/repos", params.delete_if { |k, v| !valid_user_repos_params.include? k })
       end
       return response unless block_given?
       response.each { |el| yield el }

--- a/spec/fixtures/repos/repos_sorted_by_pushed.json
+++ b/spec/fixtures/repos/repos_sorted_by_pushed.json
@@ -1,0 +1,56 @@
+[
+  {
+    "url": "https://api.github.com/repos/octocat/Hello-World-2",
+    "html_url": "https://github.com/octocat/Hello-World-2",
+    "clone_url": "https://github.com/octocat/Hello-World-2.git",
+    "git_url": "git://github.com/octocat/Hello-World-2.git",
+    "ssh_url": "git@github.com:octocat/Hello-World-2.git",
+    "svn_url": "https://svn.github.com/octocat/Hello-World-2",
+    "owner": {
+      "login": "octocat",
+      "id": 1,
+      "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+      "url": "https://api.github.com/users/octocat"
+    },
+    "name": "Hello-World-2",
+    "description": "This your second repo!",
+    "homepage": "https://github.com",
+    "language": null,
+    "private": false,
+    "fork": false,
+    "forks": 9,
+    "watchers": 80,
+    "size": 108,
+    "master_branch": "master",
+    "open_issues": 0,
+    "pushed_at": "2011-02-26T19:06:43Z",
+    "created_at": "2011-02-26T19:01:12Z"
+  },
+  {
+    "url": "https://api.github.com/repos/octocat/Hello-World",
+    "html_url": "https://github.com/octocat/Hello-World",
+    "clone_url": "https://github.com/octocat/Hello-World.git",
+    "git_url": "git://github.com/octocat/Hello-World.git",
+    "ssh_url": "git@github.com:octocat/Hello-World.git",
+    "svn_url": "https://svn.github.com/octocat/Hello-World",
+    "owner": {
+      "login": "octocat",
+      "id": 1,
+      "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+      "url": "https://api.github.com/users/octocat"
+    },
+    "name": "Hello-World",
+    "description": "This your first repo!",
+    "homepage": "https://github.com",
+    "language": null,
+    "private": false,
+    "fork": false,
+    "forks": 9,
+    "watchers": 80,
+    "size": 108,
+    "master_branch": "master",
+    "open_issues": 0,
+    "pushed_at": "2011-01-26T19:06:43Z",
+    "created_at": "2011-01-26T19:01:12Z"
+  }
+]

--- a/spec/github/repos_spec.rb
+++ b/spec/github/repos_spec.rb
@@ -442,6 +442,8 @@ describe Github::Repos do
         github.oauth_token = OAUTH_TOKEN
         stub_get("/user/repos?access_token=#{OAUTH_TOKEN}").
           to_return(:body => fixture('repos/repos.json'), :status => 200,:headers => {:content_type => "application/json; charset=utf-8"} )
+        stub_get("/user/repos?access_token=#{OAUTH_TOKEN}&sort=pushed").
+          to_return(:body => fixture('repos/repos_sorted_by_pushed.json'), :status => 200,:headers => {:content_type => "application/json; charset=utf-8"} )
       end
 
       it "fails if user is unauthenticated" do
@@ -460,6 +462,11 @@ describe Github::Repos do
         repositories = github.repos.list
         repositories.should be_an Array
         repositories.should have(1).items
+      end
+
+      it "should return array of resources sorted by pushed_at time" do
+        repositories = github.repos.list(:sort => 'pushed')
+        repositories.first.name.should == "Hello-World-2"
       end
 
       it "should get resource information" do


### PR DESCRIPTION
GitHub api for listing repositories supports 'type', 'sort', 'direction' parameters, github_api should support them, too.

`github.repos.list(:sort => 'pushed')` doesn't work now, this pr will fix it.
