### PR TITLE
Fixed bug with editing a comment.

### DIFF
--- a/lib/github_api/issues/comments.rb
+++ b/lib/github_api/issues/comments.rb
@@ -96,7 +96,7 @@ module Github
       filter! VALID_ISSUE_COMMENT_PARAM_NAME, params
       assert_required_keys(%w[ body ], params)
 
-      patch_request("/repos/#{user}/#{repo}/issues/comments/#{comment_id}")
+      patch_request("/repos/#{user}/#{repo}/issues/comments/#{comment_id}", params)
     end
 
     # Delete a comment


### PR DESCRIPTION
The params attribute was not getting passed to the patch_request method when editing a comment.
