### PR TITLE
Getting all issues - Filter invalid

### DIFF
--- a/lib/github_api/issues.rb
+++ b/lib/github_api/issues.rb
@@ -98,9 +98,10 @@ module Github
     # = Parameters
     # <tt>:filter</tt>
     #  * <tt>assigned</tt>   Issues assigned to you (default)
-    #  * <tt>created</tt>    Issues assigned to you (default)
-    #  * <tt>mentioned</tt>  Issues assigned to you (default)
-    #  * <tt>subscribed</tt> Issues assigned to you (default)
+    #  * <tt>created</tt>    Issues created by you 
+    #  * <tt>mentioned</tt>  Issues mentioning you 
+    #  * <tt>subscribed</tt> Issues you've subscribed to updates for 
+    #  * <tt>all</tt>        All issues the user can see 
     # <tt>:milestone</tt>
     #  * Integer Milestone number
     #  * <tt>none</tt> for Issues with no Milestone.


### PR DESCRIPTION
According to the API specification, the valid filters are : 
- assigned: Issues assigned to you (default)
- created: Issues created by you
- mentioned: Issues mentioning you
- subscribed: Issues you’re subscribed to updates for
- all: All issues the authenticated user can see, regardless of particpation or creation

When trying to use "all", I have the following error : 

```
     Problem:
     Wrong value of 'all' for the parameter: filter provided for this request.
    Summary:
     Github gem checks the request parameters passed to ensure that github api is not hit unnecessairly      and fails fast.
     Resolution:
      Permitted values are: assigned, created, mentioned, subscribed, make sure these are the ones you are using
```
