### PR TITLE
Fix: PubSubHubub requests need a www-urlencoded body

### DIFF
--- a/lib/github_api/repos/pub_sub_hubbub.rb
+++ b/lib/github_api/repos/pub_sub_hubbub.rb
@@ -2,6 +2,11 @@
 
 module Github
   class Repos::PubSubHubbub < API
+    OPTIONS = {
+      :headers => {
+        CONTENT_TYPE => 'application/x-www-form-urlencoded'
+      }
+    }
 
     # Subscribe to existing topic/event through pubsubhubbub
     #
@@ -22,7 +27,7 @@ module Github
       normalize! params
       _merge_action!("subscribe", topic, callback, params)
 
-      post_request("/hub", params)
+      post_request("/hub", params, OPTIONS)
     end
 
     # Unsubscribe from existing topic/event through pubsubhubbub
@@ -44,7 +49,7 @@ module Github
       normalize! params
       _merge_action!("unsubscribe", topic, callback, params)
 
-      post_request("/hub", params)
+      post_request("/hub", params, OPTIONS)
     end
 
     # Subscribe repository to service hook through pubsubhubbub


### PR DESCRIPTION
Hi!

As the curl example in the GitHub API docs shows [http://developer.github.com/v3/repos/hooks/#pubsubhubbub], PubSubHubbub requests need to be www-urlencoded to work.

Regards.
Thomas
