### PR TITLE
Add `options` param to event requests

### DIFF
--- a/lib/github_api/activity/events.rb
+++ b/lib/github_api/activity/events.rb
@@ -33,12 +33,12 @@ module Github
     #  github.events.repository 'user-name', 'repo-name'
     #  github.events.repository 'user-name', 'repo-name' { |event| ... }
     #
-    def repository(user_name, repo_name, params={})
+    def repository(user_name, repo_name, params={}, options={})
       set :user => user_name, :repo => repo_name
       assert_presence_of user, repo
       normalize! params
 
-      response = get_request("/repos/#{user}/#{repo}/events", params)
+      response = get_request("/repos/#{user}/#{repo}/events", params, options)
       return response unless block_given?
       response.each { |el| yield el }
     end
@@ -54,12 +54,12 @@ module Github
     #  github.events.issue 'user-name', 'repo-name'
     #  github.events.issue 'user-name', 'repo-name' { |event| ... }
     #
-    def issue(user_name, repo_name, params={})
+    def issue(user_name, repo_name, params={}, options={})
       set :user => user_name, :repo => repo_name
       assert_presence_of user, repo
       normalize! params
 
-      response = get_request("/repos/#{user}/#{repo}/issues/events", params)
+      response = get_request("/repos/#{user}/#{repo}/issues/events", params, options)
       return response unless block_given?
       response.each { |el| yield el }
     end
@@ -74,12 +74,12 @@ module Github
     #  github.events.network 'user-name', 'repo-name'
     #  github.events.network 'user-name', 'repo-name' { |event| ... }
     #
-    def network(user_name, repo_name, params={})
+    def network(user_name, repo_name, params={}, options={})
       set :user => user_name, :repo => repo_name
       assert_presence_of user, repo
       normalize! params
 
-      response = get_request("/networks/#{user}/#{repo}/events", params)
+      response = get_request("/networks/#{user}/#{repo}/events", params, options)
       return response unless block_given?
       response.each { |el| yield el }
     end

--- a/lib/github_api/request.rb
+++ b/lib/github_api/request.rb
@@ -48,7 +48,12 @@ module Github
           request.body = extract_data_from_params(params) unless params.empty?
         end
       end
-      response.body
+
+      if options[:full]
+        response
+      else
+        response.body
+      end
     end
 
     private


### PR DESCRIPTION
Event requests now accept a full option in order to return the whole response.

This is useful to read the response `ETag` header used to make subsequent requests to event requests, see http://developer.github.com/v3/activity/events/

Example:

``` ruby
events = Github::Activity::Events.new
response = events.repository 'user-name', 'repo-name', {}, { :full => true }
response.headers['ETag']
```
