### PR TITLE
Preserve query params in page iterator

### DIFF
--- a/lib/github_api/page_iterator.rb
+++ b/lib/github_api/page_iterator.rb
@@ -49,13 +49,9 @@ module Github
       return nil unless has_next?
 
       response = if next_page < 1
-        parsed_query = parse_query(next_page_uri.split(QUERY_STR_SEP).last)
-        params = {}
-        if parsed_query.keys.include?('last_sha')
-          params['sha'] = parsed_query['last_sha']
-        end
+        params = parse_query next_page_uri.split(QUERY_STR_SEP).last
+        params['sha'] = params['last_sha'] if params.keys.include?('last_sha')
         params['per_page'] = parse_per_page_number(next_page_uri)
-
         page_request next_page_uri.split(QUERY_STR_SEP).first, params
       else
         params = parse_query next_page_uri.split(QUERY_STR_SEP).last


### PR DESCRIPTION
The page iterator is losing my original query params on subsequent queries. In one particular case, I was passing `since` and `until` while listing commits in a repo, and the params were subsequently lost.

First query:

```
EXECUTED: get - /repos/heroku/darwin/commits with {"since"=>"2013-02-01T00:00:00Z", "until"=>"2013-02-09T01:34:16Z"} and {}
```

Next query:

```
EXECUTED: get - https://api.github.com/repos/heroku/darwin/commits with {"sha"=>"21d474f43f8edf67abb757380f748f48bc44e77c", "per_page"=>30} and {}
```

There are two paths in `PageIterator#next` - the first path is not preserving the params. This change preserves the params and does the `sha` param setting (without removing `last_sha`).

Seems to be working for me now.
