### PR TITLE
fix for coverage badge

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
     addressable (2.2.7)
     builder (3.0.0)
     colorize (0.5.8)
-    coveralls (0.5.7)
+    coveralls (0.5.8)
       colorize
       json
       rest-client
@@ -99,7 +99,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler
-  coveralls (~> 0.5)
+  coveralls (~> 0.5.8)
   cucumber
   github_api!
   growl

--- a/github_api.gemspec
+++ b/github_api.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'webmock', '~> 1.9.0'
   gem.add_development_dependency 'vcr', '~> 2.4.0'
   gem.add_development_dependency 'simplecov', '~> 0.7.1'
-  gem.add_development_dependency 'coveralls', '~> 0.5'
+  gem.add_development_dependency 'coveralls', '~> 0.5.8'
   gem.add_development_dependency 'guard'
   gem.add_development_dependency 'guard-rspec'
   gem.add_development_dependency 'guard-cucumber'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,7 @@ require 'json'
 require 'webmock/rspec'
 require 'github_api'
 
-if RUBY_VERSION > '1.9' and ENV['COVERAGE']
+if RUBY_VERSION > '1.9' and (ENV['COVERAGE'] || ENV['TRAVIS'])
   require 'coverage_adapter'
   SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
     SimpleCov::Formatter::HTMLFormatter,


### PR DESCRIPTION
Hi, I saw that we hadn't received any builds on https://coveralls.io/r/peter-murach/github so I looked into it and noticed a couple things:

WebMock was blocking the API POST to coveralls.io, and while in the past we had recommended adding "coveralls.io" to the allowed domains list, I went ahead and added auto-detection to the gem:

https://github.com/lemurheavy/coveralls-ruby/commit/8f02a494548fa21467ecdc2a2ec31846d20d9393#L1R32

Also, since the suite is running both specs and features, I enabled coveralls for specs only (since it's 95% vs Cucumber's 74%); we're working on support for aggregate test results, but not sure yet if it's possible.

Thanks! 
