### PR TITLE
:redirect_uri while working locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ token = github.get_token( authorization_code )
 
 Once you have your access token, configure your github instance following instructions under Configuration.
 
+**Note**: If you are working locally (i.e. your app URL and callback URL are localhost), do not specify a ```:redirect_uri``` otherwise you will get a ```redirect_uri_mismatch``` error.
+
 ### Authorizations API
 
 Alternatively you can use OAuth Authorizations API. For instance, to create access token through GitHub API you required to pass your basic credentials as in the following:

--- a/lib/github_api/authorization.rb
+++ b/lib/github_api/authorization.rb
@@ -25,7 +25,7 @@ module Github
 
     # Sends authorization request to GitHub.
     # = Parameters
-    # * <tt>:redirect_uri</tt> - Required string.
+    # * <tt>:redirect_uri</tt> - Optional string.
     # * <tt>:scope</tt> - Optional string. Comma separated list of scopes.
     #   Available scopes:
     #   * (no scope) - public read-only access (includes public user profile info, public repo info, and gists).


### PR DESCRIPTION
Hi, Peter

I was using this library and was having issues with authentication while working locally. I've noticed that if you specify the `:redirect_uri` while working locally, you will get a `redirect_uri_mismatch` error. So I updated the documentation to make it a bit clearer.
