### PR TITLE
Github::Request#request fails when params are a hash

### DIFF
--- a/lib/github_api/request.rb
+++ b/lib/github_api/request.rb
@@ -35,7 +35,12 @@ module Github
 
       puts "EXECUTED: #{method} - #{path} with PARAMS: #{params}" if ENV['DEBUG']
 
-      conn_options = params.options.merge(current_options)
+      conn_options = if params.respond_to? :options
+        params.options.merge(current_options)
+      else
+        current_options
+      end
+      
       conn = connection(conn_options)
       if conn.path_prefix != '/' && path.index(conn.path_prefix) != 0
         path = (conn.path_prefix + path).gsub(/\/(\/)*/, '/')


### PR DESCRIPTION
Not sure if this is the cleanest approach, but just wanted to start a dialog and this works.

How to reproduce:

```
[36] pry(main)* Github::API.new.ratelimit
EXECUTED: get - /rate_limit with PARAMS: {}
NoMethodError: undefined method `options' for {}:Hash
from /Users/phil/Development/rbsavvy/gistr/.bundle/ruby/2.0.0/gems/github_api-0.10.1/lib/github_api/request.rb:38:in `request'
```
