### PR TITLE
Add authorization parameters in if configured

### DIFF
--- a/lib/github_api/connection.rb
+++ b/lib/github_api/connection.rb
@@ -90,7 +90,11 @@ module Github
       clear_cache unless options.empty?
       puts "OPTIONS:#{conn_options.inspect}" if ENV['DEBUG']
 
-      @connection ||= Faraday.new(conn_options.merge(:builder => stack(options)))
+      @connection ||= Faraday.new(conn_options.merge(:builder => stack(options))).tap do |conn|
+        [:client_id, :client_secret, :oauth_token].each do |auth_param|
+          conn.params[auth_param] = conn_options[auth_param] if conn_options[auth_param]
+        end
+      end
     end
 
   end # Connection

--- a/lib/github_api/connection.rb
+++ b/lib/github_api/connection.rb
@@ -91,7 +91,7 @@ module Github
       puts "OPTIONS:#{conn_options.inspect}" if ENV['DEBUG']
 
       @connection ||= Faraday.new(conn_options.merge(:builder => stack(options))).tap do |conn|
-        [:client_id, :client_secret, :oauth_token].each do |auth_param|
+        [:client_id, :client_secret].each do |auth_param|
           conn.params[auth_param] = conn_options[auth_param] if conn_options[auth_param]
         end
       end


### PR DESCRIPTION
Any kind of configured authorization parameters are not passed to api calls from instantiated client 

Again, just starting a dialog with potential fix. I can add tests if you agree this is the right fix.

``` ruby
# Assuming Conf::Github[:client_id]/Conf::Github[:client_secret] is a valid Github auth pair.
github = Github.new do |config|
  config.client_id     = Conf::Github[:client_id]
  config.client_secret = Conf::Github[:client_secret]
end

# Before patch
github.ratelimit      # => 60

# After Patch
github.ratelimit      # => 5000
```

