### PR TITLE
Get rate limit reset time

### DIFF
--- a/features/cassettes/ratelimit/get_reset.yml
+++ b/features/cassettes/ratelimit/get_reset.yml
@@ -1,0 +1,84 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://<BASIC_AUTH>@api.github.com/rate_limit?access_token=<TOKEN>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json,application/vnd.github.beta+json;q=0.5,application/json;q=0.1
+      Accept-Charset:
+      - utf-8
+      User-Agent:
+      - Github Ruby Gem 0.10.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: !binary |-
+        T0s=
+    headers:
+      !binary "U2VydmVy":
+      - !binary |-
+        R2l0SHViLmNvbQ==
+      !binary "RGF0ZQ==":
+      - !binary |-
+        VHVlLCAxMyBBdWcgMjAxMyAxNDowMzo1MCBHTVQ=
+      !binary "Q29udGVudC1UeXBl":
+      - !binary |-
+        YXBwbGljYXRpb24vanNvbjsgY2hhcnNldD11dGYtOA==
+      !binary "VHJhbnNmZXItRW5jb2Rpbmc=":
+      - !binary |-
+        Y2h1bmtlZA==
+      !binary "U3RhdHVz":
+      - !binary |-
+        MjAwIE9L
+      !binary "WC1SYXRlbGltaXQtTGltaXQ=":
+      - !binary |-
+        NTAwMA==
+      !binary "WC1SYXRlbGltaXQtUmVtYWluaW5n":
+      - !binary |-
+        NTAwMA==
+      !binary "WC1SYXRlbGltaXQtUmVzZXQ=":
+      - !binary |-
+        MTM3NjQwNjIzMA==
+      !binary "WC1HaXRodWItTWVkaWEtVHlwZQ==":
+      - !binary |-
+        Z2l0aHViLnYzOyBmb3JtYXQ9anNvbg==
+      !binary "WC1Db250ZW50LVR5cGUtT3B0aW9ucw==":
+      - !binary |-
+        bm9zbmlmZg==
+      !binary "QWNjZXNzLUNvbnRyb2wtQWxsb3ctQ3JlZGVudGlhbHM=":
+      - !binary |-
+        dHJ1ZQ==
+      !binary "QWNjZXNzLUNvbnRyb2wtRXhwb3NlLUhlYWRlcnM=":
+      - !binary |-
+        RVRhZywgTGluaywgWC1SYXRlTGltaXQtTGltaXQsIFgtUmF0ZUxpbWl0LVJl
+        bWFpbmluZywgWC1SYXRlTGltaXQtUmVzZXQsIFgtT0F1dGgtU2NvcGVzLCBY
+        LUFjY2VwdGVkLU9BdXRoLVNjb3Blcw==
+      !binary "QWNjZXNzLUNvbnRyb2wtQWxsb3ctT3JpZ2lu":
+      - !binary |-
+        Kg==
+      !binary "RXRhZw==":
+      - !binary |-
+        IjM1ZWEwYmUyYzU2OGFiNTYyOTRmYTQ3Yzg5YmY2NGU0Ig==
+      !binary "Q2FjaGUtQ29udHJvbA==":
+      - !binary |-
+        bWF4LWFnZT0wLCBwcml2YXRlLCBtdXN0LXJldmFsaWRhdGU=
+      !binary "VmFyeQ==":
+      - !binary |-
+        QWNjZXB0LUVuY29kaW5n
+      !binary "Q29udGVudC1FbmNvZGluZw==":
+      - !binary |-
+        Z3ppcA==
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA6tWKkosSVWyqlbKyczNLFGyMjUwMNBRKkrNTczMy8xLRwgU
+        pwJlDY3NzUwMzIyMDWprAfw3xVw7AAAA
+    http_version: 
+  recorded_at: Tue, 13 Aug 2013 14:03:49 GMT
+recorded_with: VCR 2.5.0

--- a/features/rate_limit.feature
+++ b/features/rate_limit.feature
@@ -14,3 +14,9 @@ Feature: Ratelimit API
     Given I want to ratelimit_remaining resource
     When I make request within a cassette named "ratelimit/get_remaining"
     Then the response should be 5000
+    
+  Scenario: Get ratelimit reset datetime
+
+    Given I want to ratelimit_reset resource
+    When I make request within a cassette named "ratelimit/get_reset"
+    Then I should get a date object with the value "2013-08-13T15:03:50+00:00"

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -27,6 +27,11 @@ Then /^the response status should be (.*)$/ do |expected_response|
   @response.status.should eql expected_response.to_i
 end
 
+Then /^I should get a date object with the value "(.*)"$/ do |value|
+  @response.class.should eql DateTime
+  @response.to_s.should eql value
+end
+
 Then /^the response should be (.*)$/ do |expected_response|
   expected_response = case expected_response
   when /false/

--- a/lib/github_api/rate_limit.rb
+++ b/lib/github_api/rate_limit.rb
@@ -14,6 +14,13 @@ module Github
 
       get_request("/rate_limit", arguments.params).rate.remaining
     end
+    
+    def ratelimit_reset(*args)
+      arguments(args)
+
+      stamp = get_request("/rate_limit", arguments.params).rate.reset
+      DateTime.strptime(stamp.to_s, '%s')
+    end
 
   end # RateLimit
 end # Github


### PR DESCRIPTION
I thought it might be useful to be able to get the DateTime when the rate limit resets, for example, if you're using Resque or some other queuing system, you'll wont want to requeue until the rate limit has been reset.
