### PR TITLE
Restrict faraday gem to version 0.8.x

### DIFF
--- a/github_api.gemspec
+++ b/github_api.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'addressable', '~> 2.3'
   gem.add_dependency 'hashie',      '>= 1.2'
-  gem.add_dependency 'faraday',     '~> 0.8', '< 0.10'
+  gem.add_dependency 'faraday',     '~> 0.8'
   gem.add_dependency 'multi_json',  '>= 1.7.5', '< 2.0'
   gem.add_dependency 'oauth2'
   gem.add_dependency 'nokogiri',    '~> 1.6.0'


### PR DESCRIPTION
Hi Guys,

I was using the `github_api` gem in a simple script and the `faraday` gem version 0.9.0 was installed, I was doing something like the following.

```
  github = Github.new oauth_token: "my_auth_token"
  repos = github.repos.list user: "cih"
```

I was getting the following error, so I checked out the `faraday` changelog and switching to version `0.8.0` worked fine.

```
/Users/chrisholmes/.rvm/gems/ruby-1.9.3-p194@jasmina/gems/faraday-0.9.0/lib/faraday/options.rb:31:in `block in update': undefined method `adapter=' for #<Faraday::ConnectionOptions:0x007fabd20b5c68> (NoMethodError)
    from /Users/chrisholmes/.rvm/gems/ruby-1.9.3-p194@jasmina/gems/faraday-0.9.0/lib/faraday/options.rb:20:in `each'
    from /Users/chrisholmes/.rvm/gems/ruby-1.9.3-p194@jasmina/gems/faraday-0.9.0/lib/faraday/options.rb:20:in `update'
    from /Users/chrisholmes/.rvm/gems/ruby-1.9.3-p194@jasmina/gems/faraday-0.9.0/lib/faraday/options.rb:7:in `from'
    from /Users/chrisholmes/.rvm/gems/ruby-1.9.3-p194@jasmina/gems/faraday-0.9.0/lib/faraday/connection.rb:59:in `initialize'
    from /Users/chrisholmes/.rvm/gems/ruby-1.9.3-p194@jasmina/gems/faraday-0.9.0/lib/faraday.rb:70:in `new'
    from /Users/chrisholmes/.rvm/gems/ruby-1.9.3-p194@jasmina/gems/faraday-0.9.0/lib/faraday.rb:70:in `new'
    from /Users/chrisholmes/.rvm/gems/ruby-1.9.3-p194@jasmina/gems/github_api-0.11.1/lib/github_api/connection.rb:93:in `connection'
    from /Users/chrisholmes/.rvm/gems/ruby-1.9.3-p194@jasmina/gems/github_api-0.11.1/lib/github_api/request.rb:40:in `request'
    from /Users/chrisholmes/.rvm/gems/ruby-1.9.3-p194@jasmina/gems/github_api-0.11.1/lib/github_api/request.rb:13:in `get_request'
    from /Users/chrisholmes/.rvm/gems/ruby-1.9.3-p194@jasmina/gems/github_api-0.11.1/lib/github_api/repos.rb:153:in `list'
    from commits_counter.rb:10:in `block in <main>'
    from commits_counter.rb:8:in `each'
    from commits_counter.rb:8:in `<main>'
```

Here is a list of installed gems

```
addressable (2.3.5)
bundler (1.3.5)
bundler-unload (1.0.1)
descendants_tracker (0.0.3)
faraday (0.9.0)
github_api (0.11.1)
hashie (2.0.5)
jwt (0.1.11)
mini_portile (0.5.2)
multi_json (1.8.4)
multi_xml (0.5.5)
multipart-post (2.0.0, 1.2.0)
nokogiri (1.6.1)
oauth2 (0.9.3)
rack (1.5.2)
rake (10.1.0)
rubygems-bundler (1.2.2)
rvm (1.11.3.8)
```

Don't know if anyone has experienced this but have created this pull request for discussion.

Chris
