### PR TITLE
Remove warning about Faraday::Builder when using Faraday 0.9.x

### DIFF
--- a/lib/github_api/connection.rb
+++ b/lib/github_api/connection.rb
@@ -78,10 +78,12 @@ module Github
     #
     def stack(options = {}, &block)
       @stack ||= begin
+        builder_class = defined?(Faraday::RackBuilder) ? Faraday::RackBuilder : Faraday::Builder
+
         if block_given?
-          Faraday::Builder.new(&block)
+          builder_class.new(&block)
         else
-          Faraday::Builder.new(&default_middleware(options))
+          builder_class.new(&default_middleware(options))
         end
       end
     end


### PR DESCRIPTION
This eliminates the `Faraday::Builder is now Faraday::RackBuilder` warning when using Faraday 0.9.x while preserving support for 0.8.x as well.
