### PR TITLE
fix typo "unkown" to "unknown" in files

### DIFF
--- a/lib/github_api/arguments.rb
+++ b/lib/github_api/arguments.rb
@@ -61,7 +61,7 @@ module Github
       self
     end
 
-    # Remove unkown keys from parameters hash.
+    # Remove unknown keys from parameters hash.
     #
     # = Parameters
     #  :recursive - boolean that toggles whether nested filtering should be applied

--- a/lib/github_api/request.rb
+++ b/lib/github_api/request.rb
@@ -39,7 +39,7 @@ module Github
     #
     def request(method, path, params) # :nodoc:
       unless METHODS.include?(method)
-        raise ArgumentError, "unkown http method: #{method}"
+        raise ArgumentError, "unknown http method: #{method}"
       end
 
       puts "EXECUTED: #{method} - #{path} with PARAMS: #{params}" if ENV['DEBUG']

--- a/spec/github/activity/notifications/list_spec.rb
+++ b/spec/github/activity/notifications/list_spec.rb
@@ -23,8 +23,8 @@ describe Github::Activity::Notifications, '#list' do
 
     it { should respond_to :all }
 
-    it 'filters unkown parameters' do
-      subject.list :unkown => true
+    it 'filters unknown parameters' do
+      subject.list :unknown => true
       a_get(request_path).with(:query => {:access_token => OAUTH_TOKEN}).
         should have_been_made
     end

--- a/spec/github/repos/contributors_spec.rb
+++ b/spec/github/repos/contributors_spec.rb
@@ -27,7 +27,7 @@ describe Github::Repos, '#contributors' do
       expect { subject.contributors user }.to raise_error(ArgumentError)
     end
 
-    it 'filters out unkown parameters' do
+    it 'filters out unknown parameters' do
       subject.contributors user, repo, :unknown => true
       a_get(request_path).with({}).should have_been_made
     end

--- a/spec/github/repos/list_spec.rb
+++ b/spec/github/repos/list_spec.rb
@@ -96,7 +96,7 @@ describe Github::Repos, '#list' do
     }
 
     it "should filter the parameters" do
-      subject.list 'user' => user, :unkown => true
+      subject.list 'user' => user, :unknown => true
       a_get(request_path).with({}).should have_been_made
     end
 

--- a/spec/github/validations/format_spec.rb
+++ b/spec/github/validations/format_spec.rb
@@ -14,7 +14,7 @@ describe Github::Validations::Format do
       }
     }
 
-    it 'fails to accept unkown value for a given parameter key' do
+    it 'fails to accept unknown value for a given parameter key' do
       actual = { 'param_a' => 'x' }
       expect {
         validator.assert_valid_values(permitted, actual)


### PR DESCRIPTION
most of this is cosmetic, but there are a few spec files where the hash arguments are misspelled...

all tests are passing with this patch
