### PR TITLE
[fix #182] require Set before calling Set.new in PropertySet

### DIFF
--- a/lib/github_api/api/config/property_set.rb
+++ b/lib/github_api/api/config/property_set.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+require 'set'
 
 module Github
   class API


### PR DESCRIPTION
fixes NameError: uninitialized constant Set in the PropertySet class
