### PR TITLE
Fix issue where milestones API did not accept "all".

### DIFF
--- a/lib/github_api/client/issues/milestones.rb
+++ b/lib/github_api/client/issues/milestones.rb
@@ -4,7 +4,7 @@ module Github
   class Client::Issues::Milestones < API
 
     VALID_MILESTONE_OPTIONS = {
-     'state' => %w[ open closed ],
+     'state' => %w[ open closed all ],
      'sort'  => %w[ due_date completeness ],
      'direction' => %w[ desc asc ]
     }.freeze # :nodoc:


### PR DESCRIPTION
See GitHub API reference
  https://developer.github.com/v3/issues/milestones/#parameters

It is already documented that it is supported in Milestones#list
  https://github.com/peter-murach/github/blob/c71f4fb8f162e0d6bc12bc8ef0aa190f953ad65e/lib/github_api/client/issues/milestones.rb#L23

---

I wasn't sure if/how/where to add specs.  I don't see options tested anywhere else, and I didn't know if there was a pattern I should be following.
