### PR TITLE
Hash does not respond to delete!

### DIFF
--- a/lib/github_api/core_ext/hash.rb
+++ b/lib/github_api/core_ext/hash.rb
@@ -11,9 +11,8 @@ class Hash # :nodoc:
   # Similar to except but modifies self
   #
   def except!(*keys)
-    copy = self.dup
-    keys.each { |key| copy.delete!(key) }
-    copy
+    keys.each { |key| delete(key) }
+    self
   end unless method_defined? :except!
 
   # Returns a new hash with all the keys converted to symbols

--- a/spec/github/core_ext/hash_spec.rb
+++ b/spec/github/core_ext/hash_spec.rb
@@ -15,6 +15,9 @@ describe Hash do
   context '#except!' do
     it "should respond to except!" do
       @nested_hash.should respond_to :except!
+      copy = @nested_hash.dup
+      copy.except!('b', 'a')
+      copy.should be_empty
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -99,11 +99,3 @@ def reset_authentication_for(object)
     object.send("#{item}=", nil)
   end
 end
-
-class Hash
-  def except(*keys)
-    cpy = self.dup
-    keys.each { |key| cpy.delete(key) }
-    cpy
-  end
-end


### PR DESCRIPTION
In `lib/github_api/core_ext/hash.rb` lines 13-17, `except!` method does not work as is using a non-existent `delete!` method:

``` ruby
def except!(*keys)
  copy = self.dup
  keys.each { |key| copy.delete!(key) }
  copy
end
```

There's a nasty re-monkeypatch in `spec_helper.rb` which is masking a bug in the real code:
- `spec_helper.rb` snippet:

``` ruby
class Hash
  def except(*keys)
    cpy = self.dup
    keys.each { |key| cpy.delete(key) }
    cpy
  end
end
```

After removing this, the test suite explodes:

```
Finished in 6.09 seconds
1743 examples, 128 failures
```

So `Hash` does not respond to `delete!`, so implement `reject!` using `delete` instead of `delete!`.
