### PR TITLE
Send correctly formatted Authorization header to github when OAUTH token is present

### DIFF
--- a/lib/github_api/request/oauth2.rb
+++ b/lib/github_api/request/oauth2.rb
@@ -18,7 +18,7 @@ module Github
 
         if token = params[ACCESS_TOKEN] and !token.empty?
           env[:url].query = build_query params
-          env[:request_headers].merge!(AUTH_HEADER => "Token token=\"#{token}\"")
+          env[:request_headers].merge!(AUTH_HEADER => "token #{token}")
         end
 
         @app.call env

--- a/spec/github/request/oauth2_spec.rb
+++ b/spec/github/request/oauth2_spec.rb
@@ -40,7 +40,7 @@ describe Github::Request::OAuth2 do
 
     it "creates header for ad hoc access token" do
       result = process(:q => 'query', :access_token => 'abc123')
-      auth_header(result).should eql 'Token token="abc123"'
+      auth_header(result).should eql 'token abc123'
     end
   end
 
@@ -53,13 +53,13 @@ describe Github::Request::OAuth2 do
     end
 
     it "creates header for access token" do
-      auth_header(process).should eql 'Token token="ABC"'
+      auth_header(process).should eql 'token ABC'
     end
 
     it "overrides default with explicit token" do
       result = process(:q => 'query', :access_token => 'abc123')
       result[:url].query.should eql 'access_token=abc123&q=query'
-      auth_header(result).should eql 'Token token="abc123"'
+      auth_header(result).should eql 'token abc123'
     end
 
     it "clears default token with explicit one" do


### PR DESCRIPTION
I ran into issues connecting to Github recently and was getting a `Faraday::ConnectionFailed` with no response when trying to create a pull request.  After hours of debugging I tried getting a list of all pull requests and Github was giving back an HTML response.

I hunted this down to it's source and [Github seems to suggest a different format](https://developer.github.com/v3/oauth/#use-the-access-token-to-access-the-api) for the `Authorization` header that is currently being used, and after I updated it here everything started magically working.

It also notes that the query params for the access token aren't needed if the header is present, but I didn't want to muck with removing that as I wasn't sure there was another purpose for overrides here (based on some of the specs you have).
