### PR TITLE
fix typo of false public, false private and change wording

### DIFF
--- a/lib/github_api/client/repos.rb
+++ b/lib/github_api/client/repos.rb
@@ -284,7 +284,7 @@ module Github
     # @option params [String] :homepage
     #   Optional string
     # @option params [Boolean] :private
-    #   Optional boolean, false to create public repos, false to create a private one
+    #   Optional boolean, true to make this a private repository, false to make it a public one
     # @option params [Boolean] :has_issues
     #   Optional boolean - true to enable issues for this repository,
     #   false to disable them


### PR DESCRIPTION
made wording consistent with other params in edit, "this repository", "make it"
made order true/private false/public consistent with create's private param docstring
