### PR TITLE
Default :per_page parameter was being ignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,7 +621,7 @@ In order to be able to create/update/remove files you need to use Contents API l
 contents = Github::Client::Repos::Contents.new oauth_token: '...'
 ```
 
-Having instantiaed the contents, to create a file do:
+Having instantiated the contents, to create a file do:
 
 ```ruby
 contents.create 'username', 'repo_name', 'full_path_to/file.ext',

--- a/lib/github_api/api/arguments.rb
+++ b/lib/github_api/api/arguments.rb
@@ -9,7 +9,6 @@ module Github
       include Validations
 
       AUTO_PAGINATION = 'auto_pagination'.freeze
-      PER_PAGE        = 'per_page'.freeze
 
       # Parameters passed to request
       attr_reader :params
@@ -101,7 +100,6 @@ module Github
         @params    = options
         @remaining = args[@required.size..-1]
         extract_pagination(options)
-        set_per_page(options)
 
         yield_or_eval(&block)
         self
@@ -244,16 +242,6 @@ module Github
       def yield_or_eval(&block)
         return unless block
         block.arity > 0 ? yield(self) : instance_eval(&block)
-      end
-
-      # Handle pagination params when they are not passed directly
-      #
-      def set_per_page(options)
-        per_page_config = api.current_options[:"#{PER_PAGE}"]
-        if (per_page_config != Github::Configuration.property_set[:"#{PER_PAGE}"])
-          options[PER_PAGE] ||=  per_page_config unless per_page_config.nil?
-        end
-        options
       end
     end # Arguments
   end # Api

--- a/lib/github_api/api/arguments.rb
+++ b/lib/github_api/api/arguments.rb
@@ -9,6 +9,7 @@ module Github
       include Validations
 
       AUTO_PAGINATION = 'auto_pagination'.freeze
+      PER_PAGE        = 'per_page'.freeze
 
       # Parameters passed to request
       attr_reader :params
@@ -100,6 +101,7 @@ module Github
         @params    = options
         @remaining = args[@required.size..-1]
         extract_pagination(options)
+        set_per_page(options)
 
         yield_or_eval(&block)
         self
@@ -242,6 +244,16 @@ module Github
       def yield_or_eval(&block)
         return unless block
         block.arity > 0 ? yield(self) : instance_eval(&block)
+      end
+
+      # Handle pagination params when they are not passed directly
+      #
+      def set_per_page(options)
+        per_page_config = api.current_options[:"#{PER_PAGE}"]
+        if (per_page_config != Github::Configuration.property_set[:"#{PER_PAGE}"])
+          options[PER_PAGE] ||=  per_page_config unless per_page_config.nil?
+        end
+        options
       end
     end # Arguments
   end # Api

--- a/lib/github_api/client/repos.rb
+++ b/lib/github_api/client/repos.rb
@@ -132,6 +132,9 @@ module Github
         permit %w[ user org type sort direction since ]
       end
       params = arguments.params
+      unless params.symbolize_keys[:per_page]
+        params.merge!(Pagination.per_page_as_param(current_options[:per_page]))
+      end
 
       response = if (user_name = params.delete('user') || user)
         get_request("/users/#{user_name}/repos", params)

--- a/lib/github_api/pagination.rb
+++ b/lib/github_api/pagination.rb
@@ -6,6 +6,8 @@ module Github
   module Pagination
     include Github::Constants
 
+    PER_PAGE        = 'per_page'.freeze
+
     # Return page links
     def links
       @links = Github::PageLinks.new(env[:response_headers])
@@ -89,6 +91,16 @@ module Github
     # otherwise <tt>false</tt>
     def has_next_page?
       page_iterator.next?
+    end
+
+    # Handle pagination params when they are not passed directly
+    #
+    def self.per_page_as_param(per_page_config)
+      params = {}
+      if (per_page_config != Github::Configuration.property_set[:per_page])
+        params[:per_page] = per_page_config unless per_page_config.nil?
+      end
+      params
     end
 
     private

--- a/lib/github_api/pagination.rb
+++ b/lib/github_api/pagination.rb
@@ -6,8 +6,6 @@ module Github
   module Pagination
     include Github::Constants
 
-    PER_PAGE        = 'per_page'.freeze
-
     # Return page links
     def links
       @links = Github::PageLinks.new(env[:response_headers])

--- a/spec/integration/arguments_spec.rb
+++ b/spec/integration/arguments_spec.rb
@@ -71,4 +71,54 @@ describe 'Arguments' do
       subject.get user, repo, milestone_id, :auto_pagination => true
     end
   end
+
+  context 'handling per_page as a parameter' do
+    let(:per_page) { 2 }
+
+    before :each do
+      stub_request(:get, url).
+       to_return(:status => 200, :body => '', :headers => {})
+    end
+
+    context 'when per_page is passed on Github init' do
+      let(:token)    { [*('a'..'z')].sample(30).join }
+      let(:instance) { Github.new(oauth_token: token, per_page: per_page) }
+      let(:response) { instance.repos.list }
+      let(:url)      { "https://api.github.com/user/repos?access_token=#{token}&per_page=#{per_page}" }
+
+      it 'passes per_page params to url' do
+        expect(response.status).to eq 200
+      end
+    end
+
+    context 'when per_page is passed on Repos initialize only' do
+      let(:repos)    { Github::Client::Repos.new(per_page: per_page) }
+      let(:response) { repos.list(user: 'fpgentil') }
+      let(:url)      { "https://api.github.com/users/fpgentil/repos?per_page=#{per_page}" }
+
+      it 'passes per_page params to url' do
+        expect(response.status).to eq 200
+      end
+    end
+
+    context 'when per_page is passed on Repos initialize and list method' do
+      let(:repos)    { Github::Client::Repos.new(per_page: per_page + 5) }
+      let(:response) { repos.list(user: 'fpgentil', per_page: per_page) }
+      let(:url)      { "https://api.github.com/users/fpgentil/repos?per_page=#{per_page}" }
+
+      it 'passes per_page params to url' do
+        expect(response.status).to eq 200
+      end
+    end
+
+    context 'when per_page is not passed as params' do
+      let(:repos)    { Github::Client::Repos.new }
+      let(:response) { repos.list(user: 'fpgentil') }
+      let(:url)      { "https://api.github.com/users/fpgentil/repos" }
+
+      it 'does not pass per_page params to url' do
+        expect(response.status).to eq 200
+      end
+    end
+  end
 end


### PR DESCRIPTION
As mentioned here #137, parameter `:per_page` was being ignored if not passed directly in `list` method.

```
token = "9ac826391b6b8f4a680cef1ed2dfee1cc3192758"
github = Github.new(oauth_token: token, per_page: 2)
response = github.repos.list
response.count
=> 26
```

```
repos = Github::Client::Repos.new(per_page: 10)
response = repos.list(user: 'fpgentil', per_page: 2)
response.count
=> 2
```

```
repos = Github::Client::Repos.new(per_page: 2)
response = repos.list(user: 'fpgentil')
response.count
=> 25
```

```
repos = Github::Client::Repos.new
response = repos.list(user: 'fpgentil')
response.count
=> 25
```

This was my approach, feedbacks are always welcome :-)