### PR TITLE
Added namespace for hooks in orgs

### DIFF
--- a/lib/github_api/client/orgs.rb
+++ b/lib/github_api/client/orgs.rb
@@ -10,6 +10,9 @@ module Github
                 'memberships',
                 'teams'
 
+    # Access to Client::Orgs::Hooks API
+    namespace :hooks
+
     # Access to Client::Orgs::Members API
     namespace :members
 


### PR DESCRIPTION
I didn't realize why I couldn't use hooks in the new gem until I found that I didn't add a namespace for it. Apologies for the oversight. Could you please merge this and re-create the gem?