### PR TITLE
Allow oauth2 1.1 or 1.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,9 @@ source 'https://rubygems.org'
 
 gemspec
 
+# Rack 2.0.x doesn't work on < Ruby 2.2
+gem 'rack', '< 2.0'
+
 group :development do
   gem 'rspec',    '~> 2.14.1'
   gem 'cucumber', '~> 2.1'

--- a/github_api.gemspec
+++ b/github_api.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'addressable', '~> 2.4.0'
   gem.add_dependency 'hashie',      '>= 3.4'
   gem.add_dependency 'faraday',     '~> 0.8', '< 0.10'
-  gem.add_dependency 'oauth2',      '~> 1.0.0'
+  gem.add_dependency 'oauth2',      '~> 1.0'
   gem.add_dependency 'descendants_tracker', '~> 0.0.4'
 
   gem.add_development_dependency 'bundler'


### PR DESCRIPTION
The constrained dependency on oauth2 is preventing us from bringing in newer versions (even though we're only using github_api as a development dependency, it includes github_api as part of the runtime dependency graph, so constrains our actual application).  1.1 and 1.2 appear to work just fine, according to the specs.