### PR TITLE
Updated the tags creation parameters to reflect current api options.

### DIFF
--- a/lib/github_api/client/git_data/tags.rb
+++ b/lib/github_api/client/git_data/tags.rb
@@ -4,6 +4,7 @@ module Github
   class Client::GitData::Tags < API
     # This tags api only deals with tag objects -
     # so only annotated tags, not lightweight tags.
+    # Refer https://developer.github.com/v3/git/tags/#parameters
 
     VALID_TAG_PARAM_NAMES = %w[
       tag
@@ -13,8 +14,6 @@ module Github
       name
       email
       date
-      sha
-      url
       tagger
     ].freeze
 

--- a/spec/github/client/git_data/tags/create_spec.rb
+++ b/spec/github/client/git_data/tags/create_spec.rb
@@ -18,19 +18,15 @@ describe Github::Client::GitData::Tags, '#create' do
 
   let(:inputs) {
     {
-      "tag" => "v0.0.1",
-      "message" => "initial version\n",
-        "object" => {
-          "type" => "commit",
-          "sha" => "c3d0be41ecbe669545ee3e94d31ed9a4bc91ee3c",
-          "url" => "https://api.github.com/repos/octocat/Hello-World/git/commits/c3d0be41ecbe669545ee3e94d31ed9a4bc91ee3c"
-        },
-      "tagger" => {
-        "name" => "Scott Chacon",
-        "email" => "schacon@gmail.com",
-        "date" => "2011-06-17T14:53:35-07:00"
-      },
-      'unrelated' => 'giberrish'
+      "tag": "v0.0.1",
+      "message": "initial version\n",
+      "object": "c3d0be41ecbe669545ee3e94d31ed9a4bc91ee3c",
+      "type": "commit",
+      "tagger": {
+        "name": "Scott Chacon",
+        "email": "schacon@gmail.com",
+        "date": "2011-06-17T14:53:35-07:00"
+      }
     }
   }
 


### PR DESCRIPTION
Removed parameter options not listed in [this](https://developer.github.com/v3/git/tags/#parameters) list. 
