### PR TITLE
Adds support for Pull Request Reviews preview

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,15 +6,17 @@ gemspec
 gem 'rack', '< 2.0'
 
 group :development do
-  gem 'rspec',    '~> 2.14.1'
   gem 'cucumber', '~> 2.1'
-  gem 'webmock',  '~> 1.17.3'
+  gem 'rspec',    '~> 2.14.1'
   gem 'vcr',      '~> 2.6'
+  gem 'webmock',  '~> 1.17.3'
   gem 'yard',     '~> 0.8.7'
 end
 
 group :metrics do
-  gem 'coveralls', '~> 0.8.9'
-  gem 'simplecov', '~> 0.10.0'
-  gem 'yardstick', '~> 0.9.9'
+  gem 'coveralls',      require: false
+  gem 'tins',           '~> 1.6.0'
+  gem 'term-ansicolor', '~>1.3.0'
+  gem 'simplecov',      '~> 0.10.0'
+  gem 'yardstick',      '~> 0.9.9'
 end

--- a/github_api.gemspec
+++ b/github_api.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'descendants_tracker', '~> 0.0.4'
 
   gem.add_development_dependency 'bundler'
-  gem.add_development_dependency 'rake'
+  gem.add_development_dependency 'rake', '< 11.0'
 end

--- a/lib/github_api/client/pull_requests.rb
+++ b/lib/github_api/client/pull_requests.rb
@@ -3,10 +3,12 @@
 module Github
   class Client::PullRequests < API
 
-    require_all 'github_api/client/pull_requests', 'comments'
+    require_all 'github_api/client/pull_requests', 'comments', 'reviews'
 
     # Access to PullRequests::Comments API
     namespace :comments
+    # Access to PullRequests::Reviews API
+    namespace :reviews
 
     # List pull requests
     #

--- a/lib/github_api/client/pull_requests/reviews.rb
+++ b/lib/github_api/client/pull_requests/reviews.rb
@@ -1,0 +1,156 @@
+# encoding: utf-8
+
+module Github
+  class Client::PullRequests::Reviews < API
+    PREVIEW_MEDIA = "application/vnd.github.black-cat-preview+json".freeze # :nodoc:
+
+    # List reviews on a pull request
+    #
+    # @example
+    #   github = Github.new
+    #   github.pull_requests.reviews.list 'user-name', 'repo-name', number: 'pull-request-number'
+    #
+    # List pull request reviews in a repository
+    #
+    # @example
+    #   github = Github.new
+    #   github.pull_requests.reviews.list 'user-name', 'repo-name', number: 'pull-request-number'
+    #   github.pull_requests.reviews.list 'user-name', 'repo-name', number: 'pull-request-number' { |comm| ... }
+    #
+    # @api public
+    def list(*args)
+      arguments(args, required: [:user, :repo, :number])
+      params = arguments.params
+
+      params["accept"] ||= PREVIEW_MEDIA
+
+      response = get_request("/repos/#{arguments.user}/#{arguments.repo}/pulls/#{arguments.number}/reviews", params)
+      return response unless block_given?
+      response.each { |el| yield el }
+    end
+    alias_method :all, :list
+
+    # Get a single review for pull requests
+    #
+    # @example
+    #   github = Github.new
+    #   github.pull_requests.reviews.get 'user-name', 'repo-name', 'number', 'id'
+    #
+    # @example
+    #   github.pull_requests.reviews.get
+    #     user: 'user-name',
+    #     repo: 'repo-name',
+    #     number: 1,
+    #     id: 80
+    #
+    # @api public
+    def get(*args)
+      arguments(args, required: [:user, :repo, :number, :id])
+
+      params             = arguments.params
+      params["accept"] ||= PREVIEW_MEDIA
+
+      get_request("/repos/#{arguments.user}/#{arguments.repo}/pulls/#{arguments.number}/reviews/#{arguments.id}", params)
+    end
+    alias_method :find, :get
+
+    # Create a pull request review
+    #
+    # @param [Hash] params
+    # @option params [String] :event
+    #   Required string - The review action (event) to perform; can be one of
+    #   APPROVE, REQUEST_CHANGES, or COMMENT. If left blank, the API returns
+    #   HTTP 422 (Unrecognizable entity) and the review is left PENDING
+    # @option params [String] :body
+    #   Optional string. The text of the review.
+    # @option params [Array] :comments
+    #   Optional array of draft review comment objects. An array of comments
+    #   part of the review.
+    #
+    # @example
+    #  github = Github.new
+    #  github.pull_requests.reviews.create 'user-name', 'repo-name', 'number',
+    #    body: "Nice change",
+    #    event: "APPROVE",
+    #    comments: [
+    #      {
+    #        path: 'path/to/file/commented/on',
+    #        position: 10,
+    #        body:     'This looks good.'
+    #      }
+    #    ]
+    #
+    # @api public
+    def create(*args)
+      arguments(args, required: [:user, :repo, :number])
+
+      params             = arguments.params
+      params["accept"] ||= PREVIEW_MEDIA
+
+      post_request("/repos/#{arguments.user}/#{arguments.repo}/pulls/#{arguments.number}/reviews", params)
+    end
+
+    # Update a pull request review
+    #
+    # @param [Hash] params
+    # @option params [String] :state
+    #   Required string - The review action (event) to perform; can be one of
+    #   APPROVE, REQUEST_CHANGES, or COMMENT. If left blank, the API returns
+    #   HTTP 422 (Unrecognizable entity) and the review is left PENDING
+    # @optoin params [String] :body
+    #   Optional string
+    #
+    # @example
+    #  github = Github.new oauth_token: '...'
+    #  github.pull_requests.reviews.update 'user-name', 'repo-name', 'number', 'review-id'
+    #    body: "Update body",
+    #    event: "APPROVE"
+    #
+    # @api public
+    def update(*args)
+      arguments(args, required: [:user, :repo, :number, :id])
+      params = arguments.params
+
+      params["accept"] ||= PREVIEW_MEDIA
+
+      post_request("/repos/#{arguments.user}/#{arguments.repo}/pulls/#{arguments.number}/reviews/#{arguments.id}/events", params)
+    end
+
+    # @option params [String] :message
+    #   Optional string - Reason for dismissal
+    #
+    # @example
+    #  github = Github.new oauth_token: '...'
+    #  github.pull_requests.reviews.dismiss 'user-name', 'repo-name', 'number', 'review-id'
+    #    message: "I can't get to this right now."
+    #
+    # @api public
+    def dismiss(*args)
+      arguments(args, required: [:user, :repo, :number, :id])
+      params = arguments.params
+
+      params["accept"] ||= PREVIEW_MEDIA
+
+      put_request("/repos/#{arguments.user}/#{arguments.repo}/pulls/#{arguments.number}/reviews/#{arguments.id}/dismissals", params)
+    end
+
+    # List comments on a pull request review
+    #
+    # @example
+    #  github = Github.new
+    #  github.pull_requests.revieiws.comments 'user-name', 'repo-name', 'number', 'review-id'
+    #
+    # @api public
+    def comments(*args)
+      arguments(args, required: [:user, :repo, :number, :id])
+      params = arguments.params
+
+      params["accept"] ||= PREVIEW_MEDIA
+
+      response = get_request("/repos/#{arguments.user}/#{arguments.repo}/pulls/#{arguments.number}/reviews/#{arguments.id}/comments", params)
+      return response unless block_given?
+      response.each { |el| yield el }
+    end
+
+  end
+end

--- a/spec/fixtures/pull_requests/review.json
+++ b/spec/fixtures/pull_requests/review.json
@@ -1,0 +1,35 @@
+{
+  "id": 80,
+  "user": {
+    "login": "octocat",
+    "id": 1,
+    "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/octocat",
+    "html_url": "https://github.com/octocat",
+    "followers_url": "https://api.github.com/users/octocat/followers",
+    "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+    "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+    "organizations_url": "https://api.github.com/users/octocat/orgs",
+    "repos_url": "https://api.github.com/users/octocat/repos",
+    "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/octocat/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "body": "Here is the body for the review.",
+  "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+  "state": "APPROVED",
+  "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+  "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/1",
+  "_links": {
+    "html": {
+      "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+    },
+    "pull_request": {
+      "href": "https://api.github.com/repos/octocat/Hello-World/pulls/1"
+    }
+  }
+}

--- a/spec/fixtures/pull_requests/reviews.json
+++ b/spec/fixtures/pull_requests/reviews.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": 80,
+    "user": {
+      "login": "octocat",
+      "id": 1,
+      "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/octocat",
+      "html_url": "https://github.com/octocat",
+      "followers_url": "https://api.github.com/users/octocat/followers",
+      "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+      "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+      "organizations_url": "https://api.github.com/users/octocat/orgs",
+      "repos_url": "https://api.github.com/users/octocat/repos",
+      "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/octocat/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "Here is the body for the review.",
+    "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091",
+    "state": "APPROVED",
+    "html_url": "https://github.com/octocat/Hello-World/pull/1#pullrequestreview-80",
+    "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/1",
+    "_links": {
+      "html": {
+        "href": "https://github.com/octocat/Hello-World/pull/1#pullrequestreview-80"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/octocat/Hello-World/pulls/1"
+      }
+    }
+  }
+]

--- a/spec/github/client/git_data/tags/create_spec.rb
+++ b/spec/github/client/git_data/tags/create_spec.rb
@@ -16,19 +16,19 @@ describe Github::Client::GitData::Tags, '#create' do
 
   after { reset_authentication_for subject }
 
-  let(:inputs) {
+  let(:inputs) do
     {
-      "tag": "v0.0.1",
-      "message": "initial version\n",
-      "object": "c3d0be41ecbe669545ee3e94d31ed9a4bc91ee3c",
-      "type": "commit",
-      "tagger": {
-        "name": "Scott Chacon",
-        "email": "schacon@gmail.com",
-        "date": "2011-06-17T14:53:35-07:00"
+      "tag"     => "v0.0.1",
+      "message" => "initial version\n",
+      "object"  => "c3d0be41ecbe669545ee3e94d31ed9a4bc91ee3c",
+      "type"    => "commit",
+      "tagger"  => {
+        "name"  => "Scott Chacon",
+        "email" => "schacon@gmail.com",
+        "date"  => "2011-06-17T14:53:35-07:00"
       }
     }
-  }
+  end
 
   context "resouce created" do
     let(:body) { fixture('git_data/tag.json') }

--- a/spec/github/client/pull_requests/reviews/create_spec.rb
+++ b/spec/github/client/pull_requests/reviews/create_spec.rb
@@ -1,0 +1,62 @@
+# encoding: utf-8
+
+require "spec_helper"
+
+RSpec.describe Github::Client::PullRequests::Reviews, "#create" do
+  let(:user)         { "peter-murach" }
+  let(:repo)         { "github" }
+  let(:number)       { 1 }
+  let(:request_path) do
+    "/repos/#{user}/#{repo}/pulls/#{number}/reviews"
+  end
+  let(:inputs) do
+    {
+      "body"        => "Nice change",
+      "commit_id"   => "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+      "path"        => "file1.txt",
+      "position"    => 4,
+      "in_reply_to" => 4,
+      "unrelated"   => "giberrish"
+    }
+  end
+
+  before do
+    stub_post(request_path).with(inputs.except("unrelated")).to_return(
+        body: body,
+        status: status,
+        headers: { content_type: "application/json; charset=utf-8" }
+    )
+  end
+
+  after { reset_authentication_for(subject) }
+
+  context "resouce created" do
+    let(:body)   { fixture("pull_requests/review.json") }
+    let(:status) { 201 }
+
+    it { expect { subject.create }.to raise_error(ArgumentError) }
+
+    it "raises error when number is missing" do
+      expect { subject.create user, repo }.to raise_error(ArgumentError)
+    end
+
+    it "creates resource successfully" do
+      subject.create user, repo, number, inputs
+      expect(a_post(request_path).with(inputs)).to have_been_made
+    end
+
+    it "returns the resource" do
+      pull_request = subject.create user, repo, number, inputs
+      expect(pull_request).to be_a(Github::ResponseWrapper)
+    end
+
+    it "gets the request information" do
+      pull_request = subject.create user, repo, number, inputs
+      expect(pull_request.id).to eq(80)
+    end
+  end
+
+  it_should_behave_like "request failure" do
+    let(:requestable) { subject.create user, repo, number, inputs }
+  end
+end # create

--- a/spec/github/client/pull_requests/reviews/dismiss_spec.rb
+++ b/spec/github/client/pull_requests/reviews/dismiss_spec.rb
@@ -1,0 +1,45 @@
+# encoding: utf-8
+
+require "spec_helper"
+
+RSpec.describe Github::Client::PullRequests::Reviews, "#dismiss" do
+  let(:user)          { "peter-murach" }
+  let(:repo)          { "github" }
+  let(:pr_number)     { 1 }
+  let(:review_number) { 1 }
+
+  let(:status)  { 200 }
+  let(:message) { "Looks great" }
+  let(:request_path) do
+    "/repos/#{user}/#{repo}/pulls/#{pr_number}/reviews/#{review_number}/dismissals"
+  end
+
+  before do
+    stub_put(request_path).to_return(
+      message: message,
+      status: status,
+      headers: { content_type: "application/json; charset=utf-8" }
+    )
+  end
+
+  after { reset_authentication_for(subject) }
+
+  context "resource removed" do
+    it "raises error if pull request number not present" do
+      expect { subject.dismiss(user, repo) }.to raise_error(ArgumentError)
+    end
+
+    it "raises error if review number not present" do
+      expect { subject.dismiss(user, repo, pr_number) }.to raise_error(ArgumentError)
+    end
+
+    it "removes resource successfully" do
+      subject.dismiss user, repo, pr_number, review_number
+      expect(a_put(request_path)).to have_been_made
+    end
+  end
+
+  it_should_behave_like "request failure" do
+    let(:requestable) { subject.dismiss(user, repo, pr_number, review_number) }
+  end
+end # dismiss

--- a/spec/github/client/pull_requests/reviews/get_spec.rb
+++ b/spec/github/client/pull_requests/reviews/get_spec.rb
@@ -1,0 +1,60 @@
+# encoding: utf-8
+
+require "spec_helper"
+
+RSpec.describe Github::Client::PullRequests::Reviews, "#get" do
+  let(:user)         { "peter-murach" }
+  let(:repo)         { "github" }
+  let(:number)       { 1 }
+  let(:id)           { 80 }
+  let(:request_path) do
+    "/repos/#{user}/#{repo}/pulls/#{number}/reviews/#{id}"
+  end
+
+  before do
+    stub_get(request_path).to_return(
+      body: body,
+      status: status,
+      headers: { content_type: "application/json; charset=utf-8" }
+    )
+  end
+
+  after { reset_authentication_for(subject) }
+
+  context "resource found" do
+    let(:body)   { fixture("pull_requests/review.json") }
+    let(:status) { 200 }
+
+    it { should respond_to :find }
+
+    it { expect { subject.get }.to raise_error(ArgumentError) }
+
+    it "fails to get resource without pull request number" do
+      expect { subject.get user, repo }.to raise_error(ArgumentError)
+    end
+
+    it "fails to get resource without review id" do
+      expect { subject.get user, repo, number }.to raise_error(ArgumentError)
+    end
+
+    it "gets the resource" do
+      subject.get user, repo, number, id
+      expect(a_get(request_path)).to have_been_made
+    end
+
+    it "gets review information" do
+      review = subject.get user, repo, number, id
+      expect(review.id).to eq id
+      expect(review.user.login).to eq("octocat")
+    end
+
+    it "returns response wrapper" do
+      review = subject.get user, repo, number, id
+      expect(review).to be_a(Github::ResponseWrapper)
+    end
+  end
+
+  it_should_behave_like "request failure" do
+    let(:requestable) { subject.get user, repo, number, id }
+  end
+end # get

--- a/spec/github/client/pull_requests/reviews/list_spec.rb
+++ b/spec/github/client/pull_requests/reviews/list_spec.rb
@@ -1,0 +1,55 @@
+# encoding: utf-8
+
+require "spec_helper"
+
+RSpec.describe Github::Client::PullRequests::Reviews, "#list" do
+  let(:repo)   { "github" }
+  let(:user)   { "peter-murach" }
+  let(:number) { 1 }
+
+  before do
+    stub_get(request_path).to_return(
+      body: body,
+      status: status,
+      headers: { content_type: "application/json; charset=utf-8" }
+    )
+  end
+
+  after { reset_authentication_for(subject) }
+
+  context "on a pull request" do
+    let(:body)         { fixture("pull_requests/reviews.json") }
+    let(:status)       { 200 }
+    let(:request_path) do
+      "/repos/#{user}/#{repo}/pulls/#{number}/reviews"
+    end
+
+    it { should respond_to :all }
+
+    it { expect { subject.list }.to raise_error(ArgumentError) }
+
+    it "throws error if pull request number not provided" do
+      expect { subject.list user, repo }.to raise_error(ArgumentError)
+    end
+
+    it "gets the resources" do
+      subject.list user, repo, number
+      expect(a_get(request_path)).to have_been_made
+    end
+
+    it_should_behave_like "an array of resources" do
+      let(:requestable) { subject.list user, repo, number }
+    end
+
+    it "gets pull request review information" do
+      reviews = subject.list user, repo, number
+      expect(reviews.first.id).to eq(80)
+    end
+
+    it "yields to a block" do
+      yielded = []
+      result = subject.list(user, repo, number) { |obj| yielded << obj }
+      expect(yielded).to eq(result)
+    end
+  end
+end # list

--- a/spec/github/client/pull_requests/reviews/update_spec.rb
+++ b/spec/github/client/pull_requests/reviews/update_spec.rb
@@ -1,0 +1,55 @@
+# encoding: utf-8
+
+require "spec_helper"
+
+RSpec.describe Github::Client::PullRequests::Reviews, "#update" do
+  let(:user)         { "peter-murach" }
+  let(:repo)         { "github" }
+  let(:pr_number)    { 1 }
+  let(:number)       { 1 }
+  let(:request_path) do
+    "/repos/#{user}/#{repo}/pulls/#{pr_number}/reviews/#{number}/events"
+  end
+  let(:inputs) do
+    {
+      "body"  => "Nice change",
+      "event" => "APPROVE"
+    }
+  end
+
+  before do
+    stub_post(request_path).with(inputs).to_return(
+      body: body,
+      status: status,
+      headers: { content_type: "application/json; charset=utf-8" }
+    )
+  end
+
+  after { reset_authentication_for(subject) }
+
+  context "resouce updated" do
+    let(:body)   { fixture("pull_requests/review.json") }
+    let(:status) { 200 }
+
+    it { expect { subject.update }.to raise_error(ArgumentError) }
+
+    it "updates resource successfully" do
+      subject.update(user, repo, pr_number, number, inputs)
+      expect(a_post(request_path).with(inputs)).to have_been_made
+    end
+
+    it "returns the resource" do
+      review = subject.update(user, repo, pr_number, number, inputs)
+      expect(review).to be_a(Github::ResponseWrapper)
+    end
+
+    it "should get the review information" do
+      review = subject.update(user, repo, pr_number, number, inputs)
+      expect(review.user.login).to eq("octocat")
+    end
+  end
+
+  it_should_behave_like "request failure" do
+    let(:requestable) { subject.update(user, repo, pr_number, number, inputs) }
+  end
+end # update

--- a/spec/github/client/pull_requests/reviews_spec.rb
+++ b/spec/github/client/pull_requests/reviews_spec.rb
@@ -1,0 +1,9 @@
+# encoding: utf-8
+
+require "spec_helper"
+
+RSpec.describe Github::Client::PullRequests::Reviews do
+  after { reset_authentication_for subject }
+
+  it_should_behave_like "api interface"
+end # Github::Client::PullRequests::Reviews

--- a/spec/integration/pull_requests_spec.rb
+++ b/spec/integration/pull_requests_spec.rb
@@ -9,5 +9,6 @@ describe Github::Client::PullRequests, 'integration' do
   it_should_behave_like 'api interface'
 
   its(:comments) { should be_a Github::Client::PullRequests::Comments }
+  its(:reviews)  { should be_a Github::Client::PullRequests::Reviews }
 
 end # Github::PullRequests


### PR DESCRIPTION
This is an initial implementation of the new [Pull Request Reviews API](https://developer.github.com/v3/pulls/reviews/) now in preview.  I'm using this as a basis for upgrading our library ([git-reflow](https://github.com/reenhanced/gitreflow)) with Github's new review process and will keep this updated as their API matures.