### PR TITLE
Fixes URL for GET request

### DIFF
--- a/lib/github_api/client/issues/comments.rb
+++ b/lib/github_api/client/issues/comments.rb
@@ -61,7 +61,7 @@ module Github
       arguments(args, required: [:user, :repo, :id])
       params = arguments.params
 
-      get_request("/repos/#{arguments.user}/#{arguments.repo}/issues/comments/#{arguments.id}", params)
+      get_request("/repos/#{arguments.user}/#{arguments.repo}/issues/#{arguments.id}/comments", params)
     end
     alias :find :get
 

--- a/lib/github_api/client/pull_requests/comments.rb
+++ b/lib/github_api/client/pull_requests/comments.rb
@@ -58,7 +58,7 @@ module Github
     def get(*args)
       arguments(args, required: [:user, :repo, :number])
 
-      get_request("/repos/#{arguments.user}/#{arguments.repo}/pulls/comments/#{arguments.number}", arguments.params)
+      get_request("/repos/#{arguments.user}/#{arguments.repo}/pulls/#{arguments.number}/comments", arguments.params)
     end
     alias_method :find, :get
 

--- a/spec/github/client/issues/comments/get_spec.rb
+++ b/spec/github/client/issues/comments/get_spec.rb
@@ -6,7 +6,7 @@ describe Github::Client::Issues::Comments, '#get' do
   let(:user)   { 'peter-murach' }
   let(:repo)   { 'github' }
   let!(:comment_id) { 1 }
-  let(:request_path) { "/repos/#{user}/#{repo}/issues/comments/#{comment_id}" }
+  let(:request_path) { "/repos/#{user}/#{repo}/issues/#{comment_id}/comments" }
 
   before {
     stub_get(request_path).to_return(:body => body, :status => status,

--- a/spec/github/client/pull_requests/comments/get_spec.rb
+++ b/spec/github/client/pull_requests/comments/get_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Github::Client::PullRequests::Comments, '#get' do
   let(:repo) { 'github' }
   let(:pull_request_id) { 1 }
   let(:number) { 1 }
-  let(:request_path) { "/repos/#{user}/#{repo}/pulls/comments/#{number}" }
+  let(:request_path) { "/repos/#{user}/#{repo}/pulls/#{number}/comments" }
 
   before {
     stub_get(request_path).to_return(body: body, status: status,


### PR DESCRIPTION
API for issues and pull_request comments is /repos/#{owner}/#{repo}/pulls/#{number}/comments

cf. https://developer.github.com/v3/pulls/comments/
GET /repos/:owner/:repo/pulls/:number/comments