### PR TITLE
[Documentation] Fix documentation for delete in references

### DIFF
--- a/lib/github_api/client/git_data/references.rb
+++ b/lib/github_api/client/git_data/references.rb
@@ -122,7 +122,7 @@ module Github
     # @example
     #  github = Github.new
     #  github.git_data.references.delete 'user-name', 'repo-name',
-    #    ref: "refs/heads/master"
+    #    "heads/master"
     #
     # @api public
     def delete(*args)


### PR DESCRIPTION
#### Summary
Before this commit, the documentation of the method to delete a
reference was wrong:
- It suggested passing refs with the "refs" prefix. If one were to do
that the URL built would have a double "refs" prefix like
refs/refs/heads/master which would not work
- It suggested using ref as a named parameter which does not work either
This commit fixes these two problems in the documentation of the method.

#### Test Plan
I tested running the method following the new documentation and it
works.