### PR TITLE
Suppress warnings with key/in-built method collisions

### DIFF
--- a/lib/github_api/mash.rb
+++ b/lib/github_api/mash.rb
@@ -1,0 +1,5 @@
+module Github
+  class Mash < ::Hashie::Mash
+    disable_warnings
+  end
+end

--- a/lib/github_api/mash.rb
+++ b/lib/github_api/mash.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Github
   class Mash < ::Hashie::Mash
     disable_warnings

--- a/lib/github_api/response/mashify.rb
+++ b/lib/github_api/response/mashify.rb
@@ -6,8 +6,6 @@ require 'github_api/mash'
 
 module Github
   class Response::Mashify < Response
-    dependency 'hashie/mash'
-
     define_parser do |body|
       ::Github::Mash.new body
     end

--- a/lib/github_api/response/mashify.rb
+++ b/lib/github_api/response/mashify.rb
@@ -2,13 +2,14 @@
 
 require 'faraday'
 require 'hashie'
+require 'github_api/mash'
 
 module Github
   class Response::Mashify < Response
     dependency 'hashie/mash'
 
     define_parser do |body|
-      ::Hashie::Mash.new body
+      ::Github::Mash.new body
     end
 
     def parse(body)

--- a/spec/github/client/git_data/references/create_spec.rb
+++ b/spec/github/client/git_data/references/create_spec.rb
@@ -51,7 +51,7 @@ describe Github::Client::GitData::References, '#create' do
 
     it "should return the resource" do
       reference = subject.create user, repo, inputs
-      reference.first.should be_a Hashie::Mash
+      reference.first.should be_a Github::Mash
     end
 
     it "should get the reference information" do

--- a/spec/github/client/git_data/references/get_spec.rb
+++ b/spec/github/client/git_data/references/get_spec.rb
@@ -45,7 +45,7 @@ describe Github::Client::GitData::References, '#get' do
 
     it "should return mash" do
       reference = subject.get user, repo, ref
-      reference.first.should be_a Hashie::Mash
+      reference.first.should be_a Github::Mash
     end
   end
 

--- a/spec/github/client/git_data/references/list_spec.rb
+++ b/spec/github/client/git_data/references/list_spec.rb
@@ -78,7 +78,7 @@ describe Github::Client::GitData::References, '#list' do
 
     it "should be a mash type" do
       references = subject.list user, repo, :ref => ref
-      references.first.should be_a Hashie::Mash
+      references.first.should be_a Github::Mash
     end
 
     it "should get reference information" do

--- a/spec/github/client/git_data/references/update_spec.rb
+++ b/spec/github/client/git_data/references/update_spec.rb
@@ -46,7 +46,7 @@ describe Github::Client::GitData::References, '#update' do
 
     it "should return the resource" do
       reference = subject.update user, repo, ref, inputs
-      reference.first.should be_a Hashie::Mash
+      reference.first.should be_a Github::Mash
     end
 
     it "should get the reference information" do

--- a/spec/github/client/issues/labels/add_spec.rb
+++ b/spec/github/client/issues/labels/add_spec.rb
@@ -35,7 +35,7 @@ describe Github::Client::Issues::Labels, '#add' do
 
     it "should return the resource" do
       labels = subject.add user, repo, issue_id, label
-      labels.first.should be_a Hashie::Mash
+      labels.first.should be_a Github::Mash
     end
 
     it "should get the label information" do

--- a/spec/github/client/issues/labels/remove_spec.rb
+++ b/spec/github/client/issues/labels/remove_spec.rb
@@ -31,7 +31,7 @@ describe Github::Client::Issues::Labels, '#remove' do
 
     it "should return the resource" do
       labels = subject.remove user, repo, number, :label_name => label_name
-      labels.first.should be_a Hashie::Mash
+      labels.first.should be_a Github::Mash
     end
 
     it "should get the label information" do

--- a/spec/github/client/issues/labels/replace_spec.rb
+++ b/spec/github/client/issues/labels/replace_spec.rb
@@ -33,7 +33,7 @@ describe Github::Client::Issues::Labels, '#replace' do
 
     it "should return the resource" do
       labels = subject.replace user, repo, number, label
-      labels.first.should be_a Hashie::Mash
+      labels.first.should be_a Github::Mash
     end
 
     it "should get the label information" do

--- a/spec/github/mash_spec.rb
+++ b/spec/github/mash_spec.rb
@@ -1,0 +1,15 @@
+# encoding: utf-8
+
+require 'spec_helper'
+require 'github_api/mash'
+
+describe Github::Mash do
+  it 'suppresses warnings for key/method conflict' do
+    expect(Hashie.logger).to_not receive(:warn)
+    Github::Mash.new(size: 1)
+  end
+
+  it 'inherits from Hashie::Mash' do
+    expect(Github::Mash.new(size: 1)).to be_a(::Hashie::Mash)
+  end
+end

--- a/spec/shared/array_of_resources_behaviour.rb
+++ b/spec/shared/array_of_resources_behaviour.rb
@@ -10,6 +10,6 @@ shared_examples_for 'an array of resources' do
 
   it "should be a mash type" do
     objects = requestable
-    objects.first.should be_a Hashie::Mash
+    objects.first.should be_a ::Github::Mash
   end
 end


### PR DESCRIPTION
- Use a new subclass of Hashie::Mash called Github::Mash
- Fixes #298