### PR TITLE
Remove hard dependency on old Faraday versions

### DIFF
--- a/github_api.gemspec
+++ b/github_api.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'addressable', '~> 2.4.0'
   gem.add_dependency 'hashie',      '>= 3.4'
-  gem.add_dependency 'faraday',     '~> 0.8', '< 0.10'
+  gem.add_dependency 'faraday',     '~> 0.8'
   gem.add_dependency 'oauth2',      '~> 1.0'
   gem.add_dependency 'descendants_tracker', '~> 0.0.4'
   gem.add_dependency 'mime-types',  '>= 1.16', '< 3.0'


### PR DESCRIPTION
The old timeline of Faraday had some issues that were solved years ago. It was understandable to pin this gem to a very strict version scheme. However, there are newer versions of Faraday that don't break this gem, at least on my tests. The current dependency on Faraday makes impossible to use this gem with other gems that depend on newer versions of Faraday.

I removed the upper limit to leave the dependency resolution open to newer versions of Faraday.

Signed-off-by: David Calavera <david.calavera@gmail.com>