### PR TITLE
Avoid Ruby warnings

### DIFF
--- a/lib/github_api/api.rb
+++ b/lib/github_api/api.rb
@@ -24,9 +24,9 @@ module Github
     include Request::Verbs
     include RateLimit
 
-    attr_reader *Github.configuration.property_names
+    attr_reader(*Github.configuration.property_names)
 
-    attr_accessor *Validations::VALID_API_KEYS
+    attr_accessor(*Validations::VALID_API_KEYS)
 
     attr_accessor :current_options
 
@@ -209,7 +209,7 @@ module Github
     #
     # @api private
     def filter_callbacks(kind, action_name)
-      matched_callbacks = self.class.send("#{kind}_callbacks").select do |callback|
+      self.class.send("#{kind}_callbacks").select do |callback|
         callback[:only].nil? || callback[:only].include?(action_name)
       end
     end

--- a/lib/github_api/client/authorizations/app.rb
+++ b/lib/github_api/client/authorizations/app.rb
@@ -47,7 +47,7 @@ module Github
       if arguments.client_id
         begin
           get_request("/applications/#{arguments.client_id}/tokens/#{arguments.access_token}", params)
-        rescue Github::Error::NotFound => e
+        rescue Github::Error::NotFound
           nil
         end
       else

--- a/lib/github_api/client/markdown.rb
+++ b/lib/github_api/client/markdown.rb
@@ -49,7 +49,7 @@ module Github
     #
     def render_raw(*args)
       params = arguments(args).params
-      mime_type, params['data'] = params['mime'], args.shift
+      params['data'] = args.shift
       params['raw'] = true
       params['accept'] = params.fetch('accept') { 'text/plain' }
 

--- a/lib/github_api/client/repos.rb
+++ b/lib/github_api/client/repos.rb
@@ -278,7 +278,6 @@ module Github
       arguments(args, required: [:user, :repo]) do
         permit %w[ anon ]
       end
-      params = arguments.params
 
       response = get_request("/repos/#{arguments.user}/#{arguments.repo}/contributors", arguments.params)
       return response unless block_given?
@@ -338,7 +337,6 @@ module Github
     # @api public
     def delete(*args)
       arguments(args, required: [:user, :repo])
-      params = arguments.params
 
       delete_request("/repos/#{arguments.user}/#{arguments.repo}", arguments.params)
     end

--- a/lib/github_api/client/repos/collaborators.rb
+++ b/lib/github_api/client/repos/collaborators.rb
@@ -21,7 +21,6 @@ module Github
     # @api public
     def list(*args)
       arguments(args, required: [:user, :repo])
-      params = arguments.params
 
       response = get_request("/repos/#{arguments.user}/#{arguments.repo}/collaborators", arguments.params)
       return response unless block_given?

--- a/lib/github_api/client/repos/releases/assets.rb
+++ b/lib/github_api/client/repos/releases/assets.rb
@@ -35,7 +35,7 @@ module Github
     #
     # @api public
     def get(*args)
-      params = arguments(args, required: [:owner, :repo, :id]).params
+      arguments(args, required: [:owner, :repo, :id]).params
 
       get_request("/repos/#{arguments.owner}/#{arguments.repo}/releases/assets/#{arguments.id}" , arguments.params)
     end

--- a/lib/github_api/error.rb
+++ b/lib/github_api/error.rb
@@ -21,7 +21,7 @@ module Github
       end
 
       def backtrace
-        if @response_message && @response_message.respond_to?(:backtrace)
+        if @response_message.respond_to?(:backtrace)
           @response_message.backtrace
         else
           super

--- a/lib/github_api/ext/faraday.rb
+++ b/lib/github_api/ext/faraday.rb
@@ -7,7 +7,7 @@ module Faraday
       def params_encoder(encoder = nil)
         if encoder
           @encoder = encoder
-        else
+        elsif defined?(@encoder)
           @encoder
         end
       end

--- a/lib/github_api/request/jsonize.rb
+++ b/lib/github_api/request/jsonize.rb
@@ -32,7 +32,6 @@ module Github
     end
 
     def request_with_body?(env)
-      type = request_type(env)
       has_body?(env) and safe_to_modify?(env)
     end
 

--- a/lib/github_api/response_wrapper.rb
+++ b/lib/github_api/response_wrapper.rb
@@ -19,6 +19,7 @@ module Github
       @response    = response
       @current_api = current_api
       @env         = response.env
+      @body        = nil
     end
 
     # Overwrite methods to hash keys

--- a/spec/github/paged_request_spec.rb
+++ b/spec/github/paged_request_spec.rb
@@ -6,7 +6,7 @@ describe Github::PagedRequest, '#page_request' do
   let(:current_api) { Github::Client::Repos.new }
   let(:path) { "/repositories/"}
   let(:klass) {
-    klass = Class.new do
+    Class.new do
       include Github::PagedRequest
     end
   }

--- a/spec/github/validations/required_spec.rb
+++ b/spec/github/validations/required_spec.rb
@@ -6,7 +6,7 @@ require 'github_api/core_ext/hash'
 describe Github::Validations::Required do
 
   let(:validator) {
-    klaz = Class.new.extend(described_class)
+    Class.new.extend(described_class)
   }
 
   context '#assert_required_keys' do


### PR DESCRIPTION
This PR was made when working on removing warnings in another project, and there were a few warnings output from this project.

To avoid warnings, this PR:

  - removes unused variables
  - adds parentheses when Ruby complains
  - tries to do as little as possible while still avoiding the warning