### PR TITLE
Fix crash on require 'github_api'

### DIFF
--- a/lib/github_api/configuration.rb
+++ b/lib/github_api/configuration.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 require_relative 'api/config'
+require_relative 'version'
 
 module Github
   # Stores the configuration


### PR DESCRIPTION
Without this patch I get the following error on `require 'github_api'`
```
rescue in block (2 levels) in require': There was an error while trying to load the gem 'github_api'. (Bundler::GemRequireError)
Gem Load Error is: uninitialized constant Github::VERSION
Backtrace for gem load error is:
.../github_api-0.18.0/lib/github_api/configuration.rb:47:in `<class:Configuration>'
more backtrace
```