### PR TITLE
Fix/refs passing

### DIFF
--- a/lib/github_api/client/git_data/references.rb
+++ b/lib/github_api/client/git_data/references.rb
@@ -35,8 +35,8 @@ module Github
       repo = arguments.repo
 
       response = if (ref = params.delete('ref'))
-        validate_reference ref
-        get_request("/repos/#{user}/#{repo}/git/refs/#{ref}", params)
+        formatted_ref = validate_reference ref
+        get_request("/repos/#{user}/#{repo}/git/#{formatted_ref}", params)
       else
         get_request("/repos/#{user}/#{repo}/git/refs", params)
       end
@@ -143,6 +143,8 @@ module Github
       unless VALID_REF_PARAM_VALUES['ref'] =~ refs
         raise ArgumentError, "Provided 'reference' is invalid"
       end
+
+      refs
     end
   end # GitData::References
 end # Github

--- a/spec/github/client/git_data/references/list_spec.rb
+++ b/spec/github/client/git_data/references/list_spec.rb
@@ -6,7 +6,7 @@ describe Github::Client::GitData::References, '#list' do
   let(:user) { 'peter-murach' }
   let(:repo) { 'github' }
   let(:ref) { "heads/master" }
-  let(:request_path) { "/repos/#{user}/#{repo}/git/refs/#{ref}".gsub(/(\/)+/, '/') }
+  let(:request_path) { "/repos/#{user}/#{repo}/git/refs/#{ref.gsub(/^\/?refs\//, '')}".gsub(/(\/)+/, '/') }
 
   before {
     stub_get(request_path).to_return(:body => body, :status => status,


### PR DESCRIPTION
Currently `Github::Client::GitData::References.list(user, repo, :ref => ref)` with `ref = "/refs/heads/lleger-refactor"` is not working.
Tests were passing but request mocking was on `.../refs/refs/heads/lleger-refactor` and not `.../refs/heads/lleger-refactor`.