### PR TITLE
Update Faraday dependency

### DIFF
--- a/github_api.gemspec
+++ b/github_api.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'addressable', '~> 2.4'
   gem.add_dependency 'hashie',      '~> 3.5', '>= 3.5.2'
-  gem.add_dependency 'faraday',     '~> 0.8'
+  gem.add_dependency 'faraday',     '< 1.0'
   gem.add_dependency 'oauth2',      '~> 1.0'
   gem.add_dependency 'descendants_tracker', '~> 0.0.4'
 


### PR DESCRIPTION
I think there may have been a mistake in https://github.com/piotrmurach/github/pull/316. It looks like Faraday was pinned down to `~> 0.8` when the intent was (hopefully) to allow newer versions.