### PR TITLE
Adds ability to fetch per-repo license information

### DIFF
--- a/lib/github_api/client/repos/contents.rb
+++ b/lib/github_api/client/repos/contents.rb
@@ -33,6 +33,23 @@ module Github
       get_request("/repos/#{arguments.user}/#{arguments.repo}/readme", arguments.params)
     end
 
+    # Get the LICENSE
+    #
+    # This method returns the contents of the repository's license file, if one is detected.
+    #
+    # @param [Hash] params
+    #
+    # @example
+    #   github = Github.new
+    #   github.repos.contents.license 'user-name', 'repo-name'
+    #
+    # @api public
+    def license(*args)
+      arguments(args, required: [:user, :repo])
+
+      get_request("/repos/#{arguments.user}/#{arguments.repo}/license", arguments.params)
+    end
+    
     # Get contents
     #
     # This method returns the contents of any file or directory in a repository.

--- a/spec/unit/api/actions_spec.rb
+++ b/spec/unit/api/actions_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe Github::API, '#actions' do
   let(:api) { Github::Client::Repos::Contents }
 
   it "lists all available actions for an api class" do
-    expect(api.actions).to eq([:archive, :create, :delete, :find, :get, :readme, :update])
+    expect(api.actions).to eq([:archive, :create, :delete, :find, :get, :license, :readme, :update])
   end
 
   it "lists all available actions for an api instance" do
-    expect(api.new.actions).to eq([:archive, :create, :delete, :find, :get, :readme, :update])
+    expect(api.new.actions).to eq([:archive, :create, :delete, :find, :get, :license, :readme, :update])
   end
 end


### PR DESCRIPTION
The Github Licenses API uses the open source Ruby Gem Licensee to
attempt to identify the project's license. Licensee matches the contents
of a project's LICENSE file (if it exists) against a short list of known
licenses. As a result, the API does not take into account the licenses
of project dependencies or other means of documenting a project's license
such as references to the license name in the documentation.

If a license is matched, the license key and name returned conforms to
the SPDX specification.

Signed-off-by: zachwick <zach@zachwick.com>