### PR TITLE
Add 'has_projects' to the list of valid repo options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,6 @@ branches:
   only: master
 notifications:
   email: false
+before_install:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'

--- a/lib/github_api/client/repos.rb
+++ b/lib/github_api/client/repos.rb
@@ -32,6 +32,7 @@ module Github
       homepage
       private
       has_issues
+      has_projects
       has_wiki
       has_downloads
       team_id


### PR DESCRIPTION
Quotting https://developer.github.com/v3/repos/#edit

```
has_projects  boolean  Either true to enable projects for this
                       repository or false to disable them. Default:
                       true. Note: If you're creating a repository in an
                       organization that has disabled repository
                       projects, the default is false, and if you pass
                       true, the API returns an error.
```