### PR TITLE
fix: Avoid error in error message

### DIFF
--- a/lib/github_api/request.rb
+++ b/lib/github_api/request.rb
@@ -52,7 +52,7 @@ module Github
     # @api private
     def call(current_options, params)
       unless HTTP_METHODS.include?(action)
-        raise ArgumentError, "unknown http method: #{method}"
+        raise ArgumentError, "unknown http method: #{action}"
       end
 
       puts "EXECUTED: #{action} - #{path} with PARAMS: #{params.request_params}" if ENV['DEBUG']


### PR DESCRIPTION
This PR fixes a hidden error (which won't happen often) by fixing a typo.