### PR TITLE
Adapt to SimpleCov deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ rvm:
   - 2.2.9
   - 2.3.6
   - 2.4.3
-  - 2.5.0
+  - 2.5.8
+  - 2.6.6
+  - 2.7.1
   - ruby-head
   - jruby-9000
   - jruby-head
@@ -17,7 +19,5 @@ matrix:
     - rvm: ruby-head
     - rvm: jruby-head
   fast_finish: true
-branches:
-  only: master
 notifications:
   email: false

--- a/github_api.gemspec
+++ b/github_api.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'oauth2',      '~> 1.0'
   gem.add_dependency 'descendants_tracker', '~> 0.0.4'
 
-  gem.add_development_dependency 'bundler', '>= 1.5.0', '< 2.0'
+  gem.add_development_dependency 'bundler',  '>= 1.5.0', '< 3'
   gem.add_development_dependency 'rake',     '< 11.0'
   gem.add_development_dependency 'cucumber', '~> 2.1'
   gem.add_development_dependency 'rspec',    '~> 2.14.1'

--- a/spec/coverage_adapter.rb
+++ b/spec/coverage_adapter.rb
@@ -1,7 +1,7 @@
 require 'simplecov'
 require 'coveralls'
 
-SimpleCov.adapters.define 'github_api' do
+SimpleCov.profiles.define 'github_api' do
   add_filter "/spec/"
   add_filter "/features/"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,12 +4,14 @@ if RUBY_VERSION > '1.9' and (ENV['COVERAGE'] || ENV['TRAVIS'])
   require 'simplecov'
   require 'coveralls'
 
-  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+  SimpleCov.formatters = [
     SimpleCov::Formatter::HTMLFormatter,
     Coveralls::SimpleCov::Formatter
   ]
   SimpleCov.start do
     command_name 'ci'
+
+    add_filter '/spec/'
   end
 end
 


### PR DESCRIPTION
We adapt to some changes in the SimpleCov public API.

We also exclude the `spec` subdirectory from line coverage
calculations in order to avoid spurious coverage fluctuations.