### PR TITLE
[CVE-2020-8130] Use secure Rake version

### DIFF
--- a/github_api.gemspec
+++ b/github_api.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'descendants_tracker', '~> 0.0.4'
 
   gem.add_development_dependency 'bundler',  '>= 1.5.0', '< 3'
-  gem.add_development_dependency 'rake',     '< 11.0'
+  gem.add_development_dependency 'rake',     '>= 12.3.3', '< 14'
   gem.add_development_dependency 'cucumber', '~> 2.1'
   gem.add_development_dependency 'rspec',    '~> 3'
   gem.add_development_dependency 'rspec-its','~> 1'


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2020-8130