### PR TITLE
Remove unnecessary hashie dependency specifier

### DIFF
--- a/github_api.gemspec
+++ b/github_api.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.extra_rdoc_files = ["LICENSE.txt", "README.md", "CHANGELOG.md"]
 
   gem.add_dependency "addressable", "~> 2.4"
-  gem.add_dependency "hashie",      "~> 3.5", ">= 3.5.2"
+  gem.add_dependency "hashie",      ">= 3.5.2"
   gem.add_dependency "faraday",     ">= 0.8", "< 2"
   gem.add_dependency "oauth2",      "~> 1.0"
   gem.add_dependency "descendants_tracker", "~> 0.0.4"


### PR DESCRIPTION
The hashie gem is now up to version 4.1.0, and the dependency specifier in the gemspec file is locked to `~> 3.5`, meaning you can't get to hashie 4.x.