### PR TITLE
Enable bundler caching for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 ---
 language: ruby
+cache: bundler
 before_install: "gem install bundler -v '< 2.0'"
 script: "bundle exec rake ci"
 rvm:


### PR DESCRIPTION
Would be interested to know why bundler cache hasn't been enabled for Travis. Thank you.