### PR TITLE
Suppress the oauth_token as a url parameter while transforming it into an Authorization token header

### DIFF
--- a/lib/github_api/request/oauth2.rb
+++ b/lib/github_api/request/oauth2.rb
@@ -19,7 +19,7 @@ module Github
         params = { ACCESS_TOKEN => @token }.update query_params(env[:url])
 
         if token = params[ACCESS_TOKEN] and !token.empty?
-          env[:url].query = build_query params
+          env[:url].query = build_query params.except(ACCESS_TOKEN)
           env[:request_headers].merge!(AUTH_HEADER => "token #{token}")
         end
 


### PR DESCRIPTION
This eliminates an error that the Github service emits about using their deprecated url token authentication mechanism.